### PR TITLE
feat: optimize schema relevance pipeline, reduce embedding API calls from ~18 to 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,23 @@ nlp2sql inspect --database-url postgresql://localhost/mydb
 nlp2sql benchmark --database-url postgresql://localhost/mydb
 ```
 
+## How It Works
+
+```
+Question ──► Cache check ──► Schema retrieval ──► Relevance filtering ──► Context building ──► AI generation ──► Validation
+                                    │                     │                      │
+                              SchemaRepository    FAISS + TF-IDF hybrid   Reuses precomputed
+                              (+ disk cache)      + batch scoring          relevance scores
+```
+
+1. **Schema retrieval** -- Fetches tables from database via `SchemaRepository` (with disk cache for Redshift)
+2. **Relevance filtering** -- FAISS dense search + TF-IDF sparse search (50/50 hybrid) finds candidate tables; batch scoring refines with precomputed embeddings
+3. **Context building** -- Builds optimized schema context within token limits, reusing scores from step 2 (zero additional embedding calls)
+4. **SQL generation** -- AI provider (OpenAI, Anthropic, or Gemini) generates SQL from question + schema context
+5. **Validation** -- SQL syntax and safety checks before returning results
+
+See [Architecture](docs/ARCHITECTURE.md) for the detailed flow with method references and design decisions.
+
 ## Provider Comparison
 
 | Provider | Context Size | Best For |
@@ -147,16 +164,20 @@ See [Configuration](docs/CONFIGURATION.md) for detailed provider setup.
 
 ## Architecture
 
+Clean Architecture (Ports & Adapters) with three layers: core entities, port interfaces, and adapter implementations. The schema management layer uses FAISS + TF-IDF hybrid search for relevance filtering at scale.
+
 ```
 nlp2sql/
-├── core/           # Business entities
-├── ports/          # Interfaces/abstractions
-├── adapters/       # External implementations (AI providers, databases)
-├── services/       # Application services
-├── schema/         # Schema management and embeddings
-├── config/         # Configuration
-└── exceptions/     # Custom exceptions
+├── core/           # Business entities (pure Python, no dependencies)
+├── ports/          # Interfaces (AIProviderPort, SchemaRepositoryPort, EmbeddingProviderPort)
+├── adapters/       # Implementations (OpenAI, Anthropic, Gemini, PostgreSQL, Redshift)
+├── services/       # Orchestration (QueryGenerationService)
+├── schema/         # Schema management (SchemaManager, SchemaAnalyzer, SchemaEmbeddingManager)
+├── config/         # Pydantic Settings configuration
+└── exceptions/     # Custom exception hierarchy
 ```
+
+See [Architecture](docs/ARCHITECTURE.md) for the full component diagram, data flow, and design decisions.
 
 ## Development
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -4,6 +4,50 @@ Complete reference for the nlp2sql Python API and CLI.
 
 ## Python API
 
+### Request Flow
+
+The three entry points differ in lifecycle and performance characteristics:
+
+```
+generate_sql_from_db(question)
+  └─ create_and_initialize_service()     # creates service + loads schema every call
+       └─ create_query_service()          # wires components (AI adapter, repository, embeddings)
+            └─ service.initialize()       # fetches schema, builds FAISS index (skips if cached on disk)
+                 └─ service.generate_sql()
+
+create_and_initialize_service()          # init once, reuse for many queries (recommended)
+  └─ create_query_service()
+       └─ service.initialize()
+            └─ service.generate_sql()    # schema + FAISS index already loaded
+            └─ service.generate_sql()    # in-memory caches warm
+
+create_query_service()                   # full manual control
+  └─ caller must call service.initialize() before first query
+```
+
+**When to use which:**
+
+| Function | Best for | Schema loading |
+|----------|----------|----------------|
+| `generate_sql_from_db` | One-off scripts, notebooks | Every call (init + query) |
+| `create_and_initialize_service` | APIs, multi-query sessions | Once at startup |
+| `create_query_service` | Custom initialization logic | Manual (`initialize()`) |
+
+For multiple queries, always prefer `create_and_initialize_service` -- it loads the schema and FAISS index once, and subsequent `generate_sql()` calls benefit from in-memory caches:
+
+```python
+# Init once, query many times
+service = await create_and_initialize_service(
+    database_url="postgresql://user:pass@localhost:5432/db",
+    ai_provider="openai",
+    api_key=os.getenv("OPENAI_API_KEY"),
+)
+
+for question in ["Count users", "Show recent orders", "Revenue by month"]:
+    result = await service.generate_sql(question)
+    print(result["sql"])
+```
+
 ### Quick Start Functions
 
 #### `generate_sql_from_db`
@@ -65,8 +109,10 @@ result2 = await service.generate_sql("Show recent orders")
 | `ai_provider` | `str` | Yes | AI provider name |
 | `api_key` | `str` | Yes | Provider API key |
 | `schema_filters` | `dict` | No | Schema filtering options |
-| `embedding_provider_type` | `str` | No | Embedding provider type |
+| `embedding_provider_type` | `str` | No | Embedding provider type (see note below) |
 | `database_type` | `DatabaseType` | No | Database type (auto-detected) |
+
+**Note on `embedding_provider_type`:** This controls how schema relevance filtering works. With `"local"` or `"openai"`, the system builds a FAISS vector index for semantic search (recommended for databases with 50+ tables). With `None` (default), the system attempts to load local embeddings silently and falls back to text-only matching if `sentence-transformers` is not installed. Text-only matching uses exact name, normalized singular/plural, and token overlap -- effective for small schemas but less accurate for large ones.
 
 #### `create_query_service`
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -62,77 +62,204 @@ graph TB
 
 ### Public API
 
-Entry points for the library. `generate_sql_from_db` provides one-line convenience, while `create_query_service` allows pre-initialization for better performance with multiple queries.
+Entry points for the library (`__init__.py`):
+
+| Function | Purpose |
+|----------|---------|
+| `generate_sql_from_db` | One-line convenience: creates service, loads schema, generates SQL, returns result |
+| `create_and_initialize_service` | Creates and initializes service once; reuse for multiple queries (recommended) |
+| `create_query_service` | Creates service with full control; caller must call `initialize()` manually |
 
 ### Service Layer
 
-**QueryGenerationService** orchestrates the entire query generation flow: schema retrieval, relevance scoring, AI provider invocation, and caching.
+**QueryGenerationService** (`services/query_service.py`) orchestrates the full pipeline:
+
+1. Check query cache
+2. Get optimal schema context via `SchemaManager`
+3. Find relevant examples (from `ExampleStore` or hardcoded fallback)
+4. Build `QueryContext` and call `AIProvider.generate_query()`
+5. Optionally optimize via `QueryOptimizerPort`
+6. Validate SQL via `AIProvider.validate_query()`
+7. Cache valid results
 
 ### Schema Management
 
-| Component | Responsibility |
-|-----------|----------------|
-| **SchemaManager** | Coordinates filtering and retrieval strategies |
-| **SchemaAnalyzer** | Scores table/column relevance, compresses schema within token limits |
-| **SchemaEmbeddingManager** | Maintains FAISS vector index for semantic search |
+| Component | File | Responsibility |
+|-----------|------|----------------|
+| **SchemaManager** | `schema/manager.py` | Coordinates filtering, relevance search, and context building |
+| **SchemaAnalyzer** | `schema/analyzer.py` | Scores table/column relevance (text + semantic), compresses schema within token limits |
+| **SchemaEmbeddingManager** | `schema/embedding_manager.py` | Maintains FAISS vector index + TF-IDF sparse index for hybrid search |
 
 ### Ports (Interfaces)
 
-Abstract contracts that define boundaries between layers:
+Abstract contracts in `ports/` that define layer boundaries:
 
-- **AIProviderPort**: Contract for AI text generation
-- **SchemaRepositoryPort**: Contract for database schema access
-- **EmbeddingProviderPort**: Contract for vector embeddings
+- **AIProviderPort** (`ports/ai_provider.py`): `generate_query()`, `validate_query()`
+- **SchemaRepositoryPort** (`ports/schema_repository.py`): `get_tables()`, `get_table_info()`, `get_related_tables()`
+- **EmbeddingProviderPort** (`ports/embedding_provider.py`): `encode()`, `get_embedding_dimension()`
+- **SchemaStrategyPort** (`ports/schema_strategy.py`): `build_context()`, `score_relevance()`, `chunk_schema()`
+- **CachePort** (`ports/cache.py`): `get()`, `set()`, `clear()`
 
 ### Adapters
 
 Concrete implementations of ports:
 
-| Layer | Adapters |
-|-------|----------|
-| AI Providers | OpenAI GPT, Anthropic Claude, Google Gemini |
-| Databases | PostgreSQL, Amazon Redshift |
-| Embeddings | Local (sentence-transformers), OpenAI |
+| Layer | Adapters | Files |
+|-------|----------|-------|
+| AI Providers | OpenAI GPT, Anthropic Claude, Google Gemini | `adapters/openai_adapter.py`, `anthropic_adapter.py`, `gemini_adapter.py` |
+| Databases | PostgreSQL, Amazon Redshift | `adapters/postgres_repository.py`, `redshift_adapter.py` |
+| Embeddings | Local (sentence-transformers), OpenAI | `adapters/local_embedding_adapter.py`, `openai_embedding_adapter.py` |
 
-## Data Flow
+## Detailed Query Flow
 
+```mermaid
+sequenceDiagram
+    participant User
+    participant QGS as QueryGenerationService
+    participant SM as SchemaManager
+    participant SEM as SchemaEmbeddingManager
+    participant SA as SchemaAnalyzer
+    participant Repo as SchemaRepository
+    participant AI as AIProvider
+
+    User->>QGS: generate_sql(question)
+    QGS->>QGS: Check query cache
+    QGS->>SM: get_optimal_schema_context(question)
+
+    SM->>SM: _find_relevant_tables(question)
+    SM->>SEM: search_similar_with_embedding(query)
+    SEM->>SEM: FAISS dense + TF-IDF sparse (50/50 hybrid)
+    SEM-->>SM: (results, query_embedding)
+
+    SM->>SEM: get_table_embeddings(table_names)
+    SEM->>SEM: Reconstruct from FAISS index (zero API calls)
+    SEM-->>SM: precomputed_element_embeddings
+
+    SM->>SA: score_relevance_batch(precomputed embeddings)
+    SA->>SA: Text scoring + semantic scoring (zero API calls)
+    SA-->>SM: scored tables
+
+    SM->>Repo: get_table_info(per table)
+    Repo-->>SM: TableInfo with columns, keys, indexes
+
+    Note over SM: Attaches relevance_score to each table dict
+
+    SM->>SA: build_context(tables with relevance_score)
+    SA->>SA: Reuses existing scores (zero API calls)
+    SA-->>SM: schema context string
+
+    SM-->>QGS: schema_context
+
+    QGS->>AI: generate_query(QueryContext)
+    AI-->>QGS: SQL + confidence + explanation
+    QGS->>AI: validate_query(sql, schema_context)
+    AI-->>QGS: validation result
+    QGS-->>User: {sql, confidence, explanation, validation}
 ```
-User Query
-    │
-    ▼
-QueryGenerationService
-    │
-    ├──► SchemaManager
-    │       │
-    │       ├──► SchemaRepository (fetch schema)
-    │       │
-    │       ├──► SchemaEmbeddingManager (semantic search)
-    │       │       │
-    │       │       └──► EmbeddingProvider
-    │       │
-    │       └──► SchemaAnalyzer (relevance scoring)
-    │
-    └──► AIProvider (generate SQL)
-            │
-            ▼
-        SQL Result + Metadata
-```
+
+### Step-by-step with file references
+
+1. **`generate_sql()`** (`services/query_service.py`) -- checks query cache, then calls `SchemaManager.get_optimal_schema_context()`
+2. **`get_optimal_schema_context()`** (`schema/manager.py`) -- checks schema cache, then calls `_find_relevant_tables()`
+3. **`_find_relevant_tables()`** (`schema/manager.py`) -- two strategies:
+   - **Strategy 1**: `SchemaEmbeddingManager.search_similar_with_embedding()` -- FAISS + TF-IDF hybrid search returns candidate tables + the query embedding
+   - **Strategy 2**: `SchemaAnalyzer.score_relevance_batch()` -- batch scores token-matched tables using precomputed query + element embeddings (reconstructed from FAISS via `get_table_embeddings()`)
+4. **`get_table_info()`** (`ports/schema_repository.py`) -- fetches full table metadata; manager attaches `relevance_score` to each table dict
+5. **`build_context()`** (`schema/analyzer.py`) -- builds schema context string within token limits; reuses pre-attached `relevance_score` (no re-scoring, zero additional embedding calls)
+6. **`generate_query()`** (`ports/ai_provider.py`) -- AI provider generates SQL from question + schema context
+7. **`validate_query()`** (`ports/ai_provider.py`) -- validates SQL syntax and safety
+
+## Schema Relevance Pipeline
+
+The pipeline in `_find_relevant_tables()` (`schema/manager.py`) uses two complementary strategies to find the most relevant tables for a query:
+
+### Strategy 1: Hybrid FAISS + TF-IDF Search
+
+`SchemaEmbeddingManager._search_similar_core()` (`schema/embedding_manager.py`) combines:
+
+- **Dense search (FAISS)**: Semantic similarity via vector embeddings (`IndexFlatIP` inner product). Captures meaning (e.g., "revenue" matches "sales_amount").
+- **Sparse search (TF-IDF)**: Exact keyword matching via `TfidfVectorizer` with unigram+bigram features. Captures exact names (e.g., "organizations" matches `organization` table).
+- **Hybrid score**: `0.5 * dense_score + 0.5 * sparse_score`. Equal weighting ensures both semantic meaning and exact keyword matches contribute.
+
+This returns candidate tables + the query embedding (for reuse downstream).
+
+### Strategy 2: Batch Scoring with Precomputed Embeddings
+
+`SchemaAnalyzer.score_relevance_batch()` (`schema/analyzer.py`) refines candidates:
+
+1. **Text-based scoring** (fast, no API calls): exact name match, normalized singular/plural matching, token overlap, column-name matching
+2. **Semantic scoring** (only for elements with text score < 0.8): uses precomputed embeddings passed from the manager, avoiding new API calls
+3. The manager passes both the `query_embedding` from Strategy 1 and `element_embeddings` reconstructed from the FAISS index via `get_table_embeddings()`
+
+### Score Reuse in build_context
+
+`SchemaManager.get_optimal_schema_context()` attaches the final `relevance_score` to each table dict before calling `SchemaAnalyzer.build_context()`. The analyzer checks for this key and skips re-scoring when present. This eliminates ~10-15 embedding API calls per query that would otherwise happen in the per-table `score_relevance()` path.
+
+**Net result**: ~1 embedding API call per query (for the initial FAISS search), down from ~15-18 without these optimizations.
+
+## Caching Layers
+
+The system has multiple caching layers:
+
+| Layer | Scope | Storage | TTL |
+|-------|-------|---------|-----|
+| **Query result cache** | Full SQL response | `CachePort` (external) | Indefinite (valid results) |
+| **Schema context cache** | Built schema string | `CachePort` (external) | Per query+db+tokens key |
+| **Table relevance cache** | Relevant tables list | In-memory dict | Per `SchemaManager` instance |
+| **All-tables cache** | Filtered table list | In-memory dict (`_schema_cache`) | Until `refresh_schema()` |
+| **FAISS + TF-IDF index** | Schema embeddings | Disk (pickle + FAISS) | Until `NLP2SQL_SCHEMA_CACHE_TTL_HOURS` expires |
+| **Query embedding cache** | Per-query embeddings | In-memory dict | Cleared per `_find_relevant_tables()` call |
+| **Repository disk cache** | Schema metadata (Redshift) | Pickle file | `NLP2SQL_SCHEMA_CACHE_TTL_HOURS` |
+
+## Design Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| **Ports & Adapters** | Swap AI/DB/embedding providers without touching core logic. Adding a new provider means implementing one port interface. |
+| **FAISS + TF-IDF hybrid (50/50)** | Semantic embeddings alone miss exact keyword matches (e.g., "count organizations" should find `organization` table). TF-IDF catches these. Equal weighting balances both signals. |
+| **Disk-cached FAISS index** | Avoids re-embedding 600+ schema elements on every run. Isolated per database+schema via MD5 hash of `{database_url}:{schema_name}`. |
+| **Precomputed embeddings in batch scoring** | `_find_relevant_tables` reuses the query embedding from FAISS search and reconstructs table embeddings from the index. Result: ~1 embedding API call per query instead of ~15. |
+| **relevance_score passthrough to build_context** | Manager already scored tables during `_find_relevant_tables`; analyzer reuses those scores in `build_context` instead of re-computing them (zero redundant API calls). |
+| **Repository disk cache (Redshift)** | Redshift's `SVV_TABLES`/`SVV_COLUMNS` queries are expensive. Bulk query + pickle cache avoids repeated system catalog scans. |
+| **Graceful embedding degradation** | System works without embeddings (text-based matching only). If `sentence-transformers` is not installed, logs a warning and continues. |
+| **Schema filters applied before indexing** | Filters reduce the number of elements indexed in FAISS, making search faster and more focused. |
 
 ## Directory Structure
 
 ```
 src/nlp2sql/
-├── core/           # Business entities (pure Python)
+├── core/           # Business entities (pure Python, no external dependencies)
+│   └── entities.py         # Query, SQLQuery, DatabaseType
 ├── ports/          # Interfaces/abstractions
+│   ├── ai_provider.py      # AIProviderPort, QueryContext, QueryResponse
+│   ├── schema_repository.py # SchemaRepositoryPort, TableInfo
+│   ├── embedding_provider.py # EmbeddingProviderPort
+│   ├── schema_strategy.py   # SchemaStrategyPort, SchemaContext, SchemaChunk
+│   ├── cache.py             # CachePort
+│   └── query_optimizer.py   # QueryOptimizerPort
 ├── adapters/       # External implementations
+│   ├── openai_adapter.py           # OpenAI GPT
+│   ├── anthropic_adapter.py        # Anthropic Claude
+│   ├── gemini_adapter.py           # Google Gemini
+│   ├── postgres_repository.py      # PostgreSQL
+│   ├── redshift_adapter.py         # Amazon Redshift (with disk cache)
+│   ├── local_embedding_adapter.py  # sentence-transformers
+│   └── openai_embedding_adapter.py # OpenAI embeddings
 ├── services/       # Application services
+│   └── query_service.py    # QueryGenerationService (orchestrator)
 ├── schema/         # Schema management
+│   ├── manager.py           # SchemaManager (coordinates strategies)
+│   ├── analyzer.py          # SchemaAnalyzer (scoring, compression)
+│   └── embedding_manager.py # SchemaEmbeddingManager (FAISS + TF-IDF)
 ├── config/         # Configuration
-└── exceptions/     # Custom exceptions
+│   └── settings.py          # Pydantic Settings (env vars)
+├── exceptions/     # Custom exception hierarchy
+└── factories.py    # RepositoryFactory
 ```
 
 ## Related Documentation
 
 - [API Reference](API.md) - Python API and CLI
-- [Configuration](CONFIGURATION.md) - Environment variables
+- [Configuration](CONFIGURATION.md) - Environment variables and design rationale
 - [Enterprise Guide](ENTERPRISE.md) - Large-scale deployment
+- [Redshift Support](Redshift.md) - Amazon Redshift setup

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -55,6 +55,13 @@ export NLP2SQL_EMBEDDING_MODEL=all-MiniLM-L6-v2
 export NLP2SQL_EMBEDDING_PROVIDER=local
 ```
 
+**Design rationale for key variables:**
+
+- **`NLP2SQL_MAX_SCHEMA_TOKENS`** -- Limits the schema context sent to the AI provider. Higher values give the AI more schema information (better accuracy for complex joins) but cost more tokens. The default 8000 covers ~20-30 tables with full column definitions. For large schemas with many relevant tables, increase to 12000-16000.
+- **`NLP2SQL_SCHEMA_CACHE_TTL_HOURS`** -- Controls when the FAISS index and schema metadata are refreshed from the database. The 24h default balances freshness against the cost of re-querying system catalogs (especially expensive for Redshift's `SVV_TABLES`/`SVV_COLUMNS`). Set lower in development or when schema changes frequently.
+- **`NLP2SQL_EMBEDDINGS_DIR`** -- Where FAISS index files and TF-IDF metadata are stored on disk. Each database+schema combination gets its own subdirectory (MD5 hash of `{database_url}:{schema_name}`). Must be writable. In containerized environments (e.g., Claude Desktop MCP), the system falls back to `/tmp/nlp2sql_embeddings` if the default `./embeddings` is read-only.
+- **`NLP2SQL_EMBEDDING_MODEL`** -- The `sentence-transformers` model for local embeddings. `all-MiniLM-L6-v2` (384 dimensions) is a good balance of speed and quality. Changing this after an index is built requires clearing the cache (`nlp2sql cache clear --embeddings`) since dimensions must match.
+
 ### General Settings
 
 | Variable | Required | Default | Description |
@@ -75,6 +82,8 @@ export TOKENIZERS_PARALLELISM=false
 ## Schema Filters
 
 Schema filters reduce the database schema to relevant tables for better performance and accuracy.
+
+**Important:** Filters are applied *before* FAISS indexing (`SchemaManager._apply_schema_filters()` in `schema/manager.py`). Fewer elements indexed means faster semantic search and a more focused index. For enterprise databases (1000+ tables), well-chosen filters can reduce indexing time from minutes to seconds.
 
 ### Filter Options
 

--- a/src/nlp2sql/schema/analyzer.py
+++ b/src/nlp2sql/schema/analyzer.py
@@ -47,8 +47,7 @@ class SchemaAnalyzer(SchemaStrategyPort):
             scoring will be disabled. For best results, provide an embedding provider.
         """
         self.embedding_provider = embedding_provider
-        # Cache for query embeddings to avoid redundant API calls during relevance scoring
-        # Key: query string, Value: embedding array
+        # Per-query embedding cache to avoid redundant API calls
         self._query_embedding_cache: Dict[str, np.ndarray] = {}
 
         if embedding_provider is None:
@@ -68,14 +67,12 @@ class SchemaAnalyzer(SchemaStrategyPort):
         current_chunk = []
         current_tokens = 0
 
-        # Sort tables by estimated relevance (larger tables first)
         sorted_tables = sorted(tables, key=lambda t: len(t.get("columns", [])), reverse=True)
 
         for table in sorted_tables:
             table_tokens = self._estimate_tokens(table)
 
             if current_tokens + table_tokens > max_chunk_size and current_chunk:
-                # Create chunk
                 chunks.append(
                     SchemaChunk(
                         tables=[t["name"] for t in current_chunk],
@@ -90,7 +87,6 @@ class SchemaAnalyzer(SchemaStrategyPort):
                 current_chunk.append(table)
                 current_tokens += table_tokens
 
-        # Add remaining tables
         if current_chunk:
             chunks.append(
                 SchemaChunk(
@@ -124,7 +120,6 @@ class SchemaAnalyzer(SchemaStrategyPort):
         element_name = schema_element.get("name", "")
         element_type = schema_element.get("type", "table")
 
-        # Multiple scoring strategies
         scores = []
         reasons = []
 
@@ -132,16 +127,13 @@ class SchemaAnalyzer(SchemaStrategyPort):
         element_name_lower = element_name.lower()
 
         # 1. Exact match (fast) - check both exact substring and normalized forms
-        # Check exact substring match first
         if element_name_lower in query_lower:
             scores.append(1.0)
             reasons.append("Exact name match in query")
         else:
-            # Check normalized forms for singular/plural matching
             normalized_element = self._normalize_word(element_name_lower)
             normalized_query = self._normalize_word(query_lower)
 
-            # Check if normalized element name is in normalized query
             if normalized_element in normalized_query and len(normalized_element) >= 3:
                 scores.append(1.0)
                 reasons.append(f"Exact name match (normalized): {element_name_lower} -> {normalized_element}")
@@ -154,11 +146,9 @@ class SchemaAnalyzer(SchemaStrategyPort):
         query_tokens = self._tokenize(query_lower)
         element_tokens = self._tokenize(element_name_lower)
 
-        # Normalize tokens for better matching (handles singular/plural)
         normalized_query_tokens = {self._normalize_word(t) for t in query_tokens}
         normalized_element_tokens = {self._normalize_word(t) for t in element_tokens}
 
-        # Check both exact token match and normalized token match
         common_tokens = set(query_tokens) & set(element_tokens)
         common_normalized_tokens = normalized_query_tokens & normalized_element_tokens
 
@@ -186,7 +176,6 @@ class SchemaAnalyzer(SchemaStrategyPort):
 
             for column in columns_to_check:
                 col_name = column.get("name", "").lower()
-                # Fast token matching without recursion
                 if col_name in query_lower:
                     column_matches += 2  # Exact match worth more
                 elif any(token in col_name for token in query_tokens):
@@ -198,7 +187,6 @@ class SchemaAnalyzer(SchemaStrategyPort):
                     scores.append(column_score)
                     reasons.append(f"Relevant columns found ({column_matches} matches)")
 
-        # Combine scores
         final_score = max(scores) if scores else 0.0
 
         # Only log significant scores to reduce overhead
@@ -212,19 +200,15 @@ class SchemaAnalyzer(SchemaStrategyPort):
         compressed = []
         current_tokens = 0
 
-        # Prioritize most important information
         for table_name, table_info in schema.items():
             if current_tokens >= target_tokens:
                 break
 
-            # Basic table info
             table_desc = f"Table: {table_name}"
 
-            # Add primary keys
             if "primary_keys" in table_info:
                 table_desc += f" (PK: {', '.join(table_info['primary_keys'])})"
 
-            # Add most important columns
             if "columns" in table_info:
                 important_cols = self._get_important_columns(table_info["columns"])
                 col_info = []
@@ -237,7 +221,6 @@ class SchemaAnalyzer(SchemaStrategyPort):
 
                 table_desc += f"\n  Columns: {', '.join(col_info)}"
 
-            # Add foreign keys (compressed)
             if table_info.get("foreign_keys"):
                 fk_info = []
                 for fk in table_info["foreign_keys"][:3]:  # Limit FKs
@@ -254,7 +237,6 @@ class SchemaAnalyzer(SchemaStrategyPort):
     async def create_embeddings(self, texts: List[str]) -> np.ndarray:
         """Create embeddings for schema elements."""
         if self.embedding_provider is None:
-            # Return empty array if no provider
             return np.array([])
         return await self.embedding_provider.encode(texts)
 
@@ -289,10 +271,13 @@ class SchemaAnalyzer(SchemaStrategyPort):
 
     async def build_context(self, context: SchemaContext, tables: List[Dict[str, Any]]) -> str:
         """Build optimized schema context for query."""
-        # Score all tables
+        # Score all tables (reuse pre-computed scores from SchemaManager when available)
         table_scores = []
         for table in tables:
-            score = await self.score_relevance(context.query, table)
+            if "relevance_score" in table:
+                score = table["relevance_score"]
+            else:
+                score = await self.score_relevance(context.query, table)
             table_scores.append((table, score))
 
         # Sort by relevance
@@ -363,7 +348,6 @@ class SchemaAnalyzer(SchemaStrategyPort):
 
     def _tokenize(self, text: str) -> List[str]:
         """Tokenize text for matching."""
-        # Split on non-alphanumeric, convert to lowercase
         tokens = re.findall(r"\w+", text.lower())
         # Handle snake_case and camelCase
         expanded_tokens = []
@@ -379,11 +363,9 @@ class SchemaAnalyzer(SchemaStrategyPort):
         self, query: str, element_name: str, schema_element: Dict[str, Any]
     ) -> float:
         """Calculate semantic similarity using embeddings."""
-        # Return 0 if no embedding provider
         if self.embedding_provider is None:
             return 0.0
 
-        # Create descriptive text for element
         element_desc = self._create_element_description(schema_element)
 
         # Get query embedding from cache or generate it (avoids N+1 API calls)
@@ -391,14 +373,11 @@ class SchemaAnalyzer(SchemaStrategyPort):
             self._query_embedding_cache[query] = await self.create_embeddings([query])
         query_embedding = self._query_embedding_cache[query]
 
-        # Get element embedding
         element_embedding = await self.create_embeddings([element_desc])
 
-        # Check if embeddings are valid
         if query_embedding.size == 0 or element_embedding.size == 0:
             return 0.0
 
-        # Calculate similarity
         similarity = cosine_similarity(query_embedding, element_embedding)[0][0]
         return float(similarity)
 
@@ -426,6 +405,8 @@ class SchemaAnalyzer(SchemaStrategyPort):
         query: str,
         schema_elements: List[Dict[str, Any]],
         use_semantic: bool = True,
+        precomputed_query_embedding: Optional[np.ndarray] = None,
+        precomputed_element_embeddings: Optional[Dict[str, np.ndarray]] = None,
     ) -> List[Tuple[Dict[str, Any], float]]:
         """Score relevance of multiple schema elements in a single batch.
 
@@ -436,6 +417,11 @@ class SchemaAnalyzer(SchemaStrategyPort):
             query: The search query
             schema_elements: List of schema elements to score
             use_semantic: Whether to use semantic similarity
+            precomputed_query_embedding: Optional precomputed query embedding to avoid
+                redundant API calls. Pass np.array([]) or None to fall back to cache/API.
+            precomputed_element_embeddings: Optional dict mapping element names to their
+                precomputed embeddings (e.g. from FAISS index). Elements missing from this
+                dict will be computed via API. Pass None to compute all via API.
 
         Returns:
             List of (element, score) tuples sorted by score descending
@@ -456,12 +442,10 @@ class SchemaAnalyzer(SchemaStrategyPort):
             # Calculate text score (same logic as score_relevance)
             score = 0.0
 
-            # Exact match
             normalized_element = self._normalize_word(element_name_lower)
             if element_name_lower in query_lower or normalized_element in query_lower:
                 score = 1.0
             else:
-                # Token match
                 element_tokens = self._tokenize(element_name_lower)
                 normalized_element_tokens = {self._normalize_word(t) for t in element_tokens}
                 common_tokens = set(query_tokens) & set(element_tokens)
@@ -471,7 +455,6 @@ class SchemaAnalyzer(SchemaStrategyPort):
                     match_count = max(len(common_tokens), len(common_normalized))
                     score = match_count / max(len(query_tokens), len(element_tokens))
 
-            # Column-based relevance for tables
             if element.get("type") == "table" and "columns" in element:
                 column_matches = 0
                 columns_to_check = element["columns"][:15]
@@ -497,7 +480,10 @@ class SchemaAnalyzer(SchemaStrategyPort):
 
             if elements_for_semantic:
                 semantic_scores = await self._calculate_semantic_similarity_batch(
-                    query, elements_for_semantic
+                    query,
+                    elements_for_semantic,
+                    precomputed_query_embedding=precomputed_query_embedding,
+                    precomputed_element_embeddings=precomputed_element_embeddings,
                 )
                 # Merge scores (take max of text and semantic)
                 for element, sem_score in semantic_scores:
@@ -510,7 +496,6 @@ class SchemaAnalyzer(SchemaStrategyPort):
             score = text_scores.get(element.get("name", ""), 0)
             results.append((element, score))
 
-        # Sort by score descending
         results.sort(key=lambda x: x[1], reverse=True)
         return results
 
@@ -518,12 +503,22 @@ class SchemaAnalyzer(SchemaStrategyPort):
         self,
         query: str,
         elements: List[Dict[str, Any]],
+        precomputed_query_embedding: Optional[np.ndarray] = None,
+        precomputed_element_embeddings: Optional[Dict[str, np.ndarray]] = None,
     ) -> List[Tuple[Dict[str, Any], float]]:
         """Calculate semantic similarity for multiple elements in one API call.
 
         Args:
             query: The search query
             elements: List of schema elements
+            precomputed_query_embedding: Optional precomputed query embedding.
+                Use this to avoid redundant API calls when the embedding was
+                already computed (e.g. during FAISS search). Pass np.array([])
+                or None to fall back to cache/API.
+            precomputed_element_embeddings: Optional dict mapping element names
+                to their precomputed embeddings (e.g. reconstructed from FAISS).
+                Elements missing from the dict will be computed via API.
+                Pass None to compute all via API (original behavior).
 
         Returns:
             List of (element, similarity_score) tuples
@@ -531,28 +526,63 @@ class SchemaAnalyzer(SchemaStrategyPort):
         if not elements or self.embedding_provider is None:
             return []
 
-        # Step 1: Create descriptions for all elements
-        descriptions = []
-        for element in elements:
-            desc = self._create_element_description(element)
-            descriptions.append(desc)
-
-        # Step 2: Get query embedding (cached)
-        if query not in self._query_embedding_cache:
-            self._query_embedding_cache[query] = await self.create_embeddings([query])
-        query_embedding = self._query_embedding_cache[query]
+        # Step 1: Get query embedding (precomputed > cache > API)
+        query_embedding = None
+        if precomputed_query_embedding is not None and precomputed_query_embedding.size > 0:
+            query_embedding = precomputed_query_embedding
+        elif query in self._query_embedding_cache:
+            query_embedding = self._query_embedding_cache[query]
+        else:
+            query_embedding = await self.create_embeddings([query])
+            self._query_embedding_cache[query] = query_embedding
 
         if query_embedding.size == 0:
             return []
 
-        # Step 3: Batch embed all element descriptions (SINGLE API CALL)
-        logger.debug("Batch embedding elements", count=len(descriptions))
-        element_embeddings = await self.create_embeddings(descriptions)
+        # Step 2: Build element embeddings matrix
+        # Use precomputed where available, compute missing ones via API
+        element_embeddings_list: List[Optional[np.ndarray]] = [None] * len(elements)
+        missing_indices = []
+        missing_descriptions = []
 
-        if element_embeddings.size == 0:
+        for i, element in enumerate(elements):
+            name = element.get("name", "")
+            if precomputed_element_embeddings and name in precomputed_element_embeddings:
+                element_embeddings_list[i] = precomputed_element_embeddings[name]
+            else:
+                missing_indices.append(i)
+                missing_descriptions.append(self._create_element_description(element))
+
+        # Compute missing element embeddings via API (if any)
+        if missing_descriptions:
+            logger.debug("Batch embedding elements", count=len(missing_descriptions))
+            computed = await self.create_embeddings(missing_descriptions)
+            if computed.size == 0:
+                # If API returned empty and we have no precomputed, bail out
+                if not precomputed_element_embeddings:
+                    return []
+            else:
+                # Handle single embedding (1D) case
+                if len(computed.shape) == 1:
+                    computed = computed.reshape(1, -1)
+                for j, idx in enumerate(missing_indices):
+                    if j < len(computed):
+                        element_embeddings_list[idx] = computed[j]
+
+        # Filter out elements that still have no embedding
+        valid_elements = []
+        valid_embeddings = []
+        for i, element in enumerate(elements):
+            if element_embeddings_list[i] is not None:
+                valid_elements.append(element)
+                valid_embeddings.append(element_embeddings_list[i])
+
+        if not valid_embeddings:
             return []
 
-        # Step 4: Calculate all similarities in memory (vectorized)
+        element_embeddings = np.array(valid_embeddings)
+
+        # Step 3: Calculate all similarities in memory (vectorized)
         results = []
         # Handle both 1D and 2D embeddings
         if len(element_embeddings.shape) == 1:
@@ -561,15 +591,15 @@ class SchemaAnalyzer(SchemaStrategyPort):
                 query_embedding.reshape(1, -1),
                 element_embeddings.reshape(1, -1)
             )[0][0]
-            if len(elements) == 1:
-                results.append((elements[0], float(similarity)))
+            if len(valid_elements) == 1:
+                results.append((valid_elements[0], float(similarity)))
         else:
             # Multiple embeddings - use batch similarity calculation
             similarities = cosine_similarity(
                 query_embedding.reshape(1, -1),
                 element_embeddings
             )[0]
-            for i, element in enumerate(elements):
+            for i, element in enumerate(valid_elements):
                 if i < len(similarities):
                     results.append((element, float(similarities[i])))
 
@@ -579,15 +609,12 @@ class SchemaAnalyzer(SchemaStrategyPort):
         """Identify important columns based on heuristics."""
         important = []
 
-        # Priority patterns
         priority_patterns = ["id", "name", "date", "amount", "total", "count", "status", "type"]
 
-        # First add primary keys and foreign keys
         for col in columns:
             if col.get("is_primary_key") or col.get("is_foreign_key"):
                 important.append(col)
 
-        # Then add columns matching priority patterns
         for col in columns:
             if col in important:
                 continue
@@ -595,7 +622,6 @@ class SchemaAnalyzer(SchemaStrategyPort):
             if any(pattern in col_name for pattern in priority_patterns):
                 important.append(col)
 
-        # Finally add remaining columns up to limit
         for col in columns:
             if col not in important:
                 important.append(col)
@@ -611,7 +637,6 @@ class SchemaAnalyzer(SchemaStrategyPort):
         if "description" in table:
             parts.append(f"Description: {table['description']}")
 
-        # Columns
         if "columns" in table:
             col_defs = []
             for col in table["columns"]:
@@ -627,14 +652,12 @@ class SchemaAnalyzer(SchemaStrategyPort):
                 col_defs.append(col_def)
             parts.append("Columns:\n" + "\n".join(col_defs))
 
-        # Relationships
         if table.get("foreign_keys"):
             fk_defs = []
             for fk in table["foreign_keys"]:
                 fk_defs.append(f"  - {fk['column']} -> {fk['ref_table']}.{fk['ref_column']}")
             parts.append("Foreign Keys:\n" + "\n".join(fk_defs))
 
-        # Sample data if requested
         if context.include_samples and "sample_data" in table:
             parts.append(f"Sample Data: {table['sample_data'][:3]}")
 

--- a/src/nlp2sql/schema/embedding_manager.py
+++ b/src/nlp2sql/schema/embedding_manager.py
@@ -116,7 +116,6 @@ class SchemaEmbeddingManager:
             logger.error("Failed to create embeddings directory", path=str(self.index_path), error=str(e))
             raise
 
-        # FAISS index for similarity search
         self.index = None
         self.id_to_schema = {}
         self.schema_to_id = {}
@@ -127,7 +126,6 @@ class SchemaEmbeddingManager:
         self.tfidf_matrix = None
         self.tfidf_texts = []
 
-        # Skip index initialization if no embedding provider
         if embedding_provider is None:
             self.embedding_dim = None
             return
@@ -151,7 +149,6 @@ class SchemaEmbeddingManager:
         else:
             self.embedding_dim = self.embedding_provider.get_embedding_dimension()
 
-        # Initialize or load index
         self._initialize_index()
 
     def _initialize_index(self) -> None:
@@ -160,7 +157,6 @@ class SchemaEmbeddingManager:
         metadata_file = self.index_path / "schema_metadata.pkl"
 
         if index_file.exists() and metadata_file.exists():
-            # Load existing index
             self.index = faiss.read_index(str(index_file))
             with open(metadata_file, "rb") as f:
                 metadata = pickle.load(f)
@@ -215,7 +211,6 @@ class SchemaEmbeddingManager:
                 provider=self.embedding_provider.provider_type,
             )
         else:
-            # Create new index
             self.index = faiss.IndexFlatIP(self.embedding_dim)  # Inner product for cosine similarity
             logger.info(
                 "Created new embedding index",
@@ -225,7 +220,6 @@ class SchemaEmbeddingManager:
 
     async def add_schema_elements(self, elements: List[Dict[str, Any]], database_type: DatabaseType) -> None:
         """Add schema elements to the embedding index."""
-        # Skip if no embedding provider
         if self.embedding_provider is None or self.index is None:
             logger.debug("Skipping schema element indexing - no embedding provider")
             return
@@ -237,11 +231,9 @@ class SchemaEmbeddingManager:
         element_keys = []  # Track keys for later mapping storage
 
         for element in elements:
-            # Create unique key
             element_key = self._create_element_key(element, database_type)
 
             if element_key not in self.schema_to_id:
-                # Create description for embedding
                 description = self._create_element_description(element)
 
                 # Skip elements with empty or invalid descriptions
@@ -297,10 +289,7 @@ class SchemaEmbeddingManager:
         # Phase 4: Add to FAISS index (mappings already stored)
         self.index.add(np.array(embeddings, dtype=np.float32))
 
-        # Update TF-IDF index
         self._update_tfidf_index(descriptions)
-
-        # Save index
         await self._save_index()
 
         logger.info(
@@ -311,21 +300,46 @@ class SchemaEmbeddingManager:
         self, query: str, top_k: int = 10, database_type: Optional[DatabaseType] = None, min_score: float = 0.3
     ) -> List[Tuple[Dict[str, Any], float]]:
         """Search for similar schema elements."""
-        # Return empty if no embedding provider or no index
+        results, _ = await self._search_similar_core(query, top_k, database_type, min_score)
+        return results
+
+    async def search_similar_with_embedding(
+        self, query: str, top_k: int = 10, database_type: Optional[DatabaseType] = None, min_score: float = 0.3
+    ) -> Tuple[List[Tuple[Dict[str, Any], float]], np.ndarray]:
+        """Search for similar schema elements and return the query embedding.
+
+        Same as search_similar() but also returns the query embedding so callers
+        can reuse it downstream without redundant API calls.
+
+        Returns:
+            Tuple of (results, query_embedding). query_embedding is np.array([])
+            when no provider, empty index, or cached result.
+        """
+        return await self._search_similar_core(query, top_k, database_type, min_score)
+
+    async def _search_similar_core(
+        self, query: str, top_k: int = 10, database_type: Optional[DatabaseType] = None, min_score: float = 0.3
+    ) -> Tuple[List[Tuple[Dict[str, Any], float]], np.ndarray]:
+        """Core search logic returning both results and query embedding.
+
+        Returns:
+            Tuple of (results, query_embedding). query_embedding is np.array([])
+            when no provider, empty index, or cached result.
+        """
+        empty_embedding = np.array([])
+
         if self.embedding_provider is None or self.index is None:
-            return []
+            return [], empty_embedding
 
         if self.index.ntotal == 0:
-            return []
+            return [], empty_embedding
 
-        # Check cache
         cache_key = f"schema_search:{query}:{top_k}:{database_type}"
         if self.cache:
             cached_result = await self.cache.get(cache_key)
             if cached_result:
-                return cached_result
+                return cached_result, empty_embedding
 
-        # Create query embedding using provider
         query_embedding = await self.embedding_provider.encode([query])
 
         # Search in FAISS (Dense Search)
@@ -377,11 +391,9 @@ class SchemaEmbeddingManager:
         for idx, data in candidates.items():
             schema_info = self.id_to_schema[idx]
 
-            # Filter by database type if specified
             if database_type and schema_info["database_type"] != database_type.value:
                 continue
 
-            # Calculate hybrid score
             hybrid_score = (data["dense_score"] * alpha) + (data["sparse_score"] * (1 - alpha))
 
             if hybrid_score < min_score:
@@ -389,19 +401,16 @@ class SchemaEmbeddingManager:
 
             final_results.append((schema_info["element"], hybrid_score))
 
-        # Sort by hybrid score
         final_results.sort(key=lambda x: x[1], reverse=True)
         results = final_results[:top_k]
 
-        # Cache results
         if self.cache:
             await self.cache.set(cache_key, results)
 
-        return results
+        return results, query_embedding
 
     async def get_table_embeddings(self, table_names: List[str], database_type: DatabaseType) -> Dict[str, np.ndarray]:
         """Get embeddings for specific tables."""
-        # Return empty if no embedding provider
         if self.embedding_provider is None or self.index is None:
             return {}
 
@@ -447,7 +456,6 @@ class SchemaEmbeddingManager:
 
     async def update_embeddings(self, elements: List[Dict[str, Any]], database_type: DatabaseType) -> None:
         """Update embeddings for existing elements."""
-        # Remove old embeddings
         for element in elements:
             element_key = self._create_element_key(element, database_type)
             if element_key in self.schema_to_id:
@@ -455,7 +463,6 @@ class SchemaEmbeddingManager:
                 old_id = self.schema_to_id[element_key]
                 self.id_to_schema[old_id]["outdated"] = True
 
-        # Add new embeddings
         await self.add_schema_elements(elements, database_type)
 
     def _create_element_key(self, element: Dict[str, Any], database_type: DatabaseType) -> str:
@@ -475,26 +482,21 @@ class SchemaEmbeddingManager:
         element_type = element.get("type", "unknown")
         element_name = element.get("name", "unnamed")
 
-        # Base description
         parts.append(f"{element_type.capitalize()} {element_name}")
 
-        # Add custom description if available
         if "description" in element:
             parts.append(element["description"])
 
-        # Add column information for tables
         if element_type == "table" and "columns" in element:
             col_names = [col.get("name", "") for col in element["columns"][:10]]
             if col_names:
                 parts.append(f"Columns: {', '.join(col_names)}")
 
-        # Add data type for columns
         if element_type == "column" and "data_type" in element:
             parts.append(f"Type: {element['data_type']}")
             if "table_name" in element:
                 parts.append(f"In table: {element['table_name']}")
 
-        # Add relationships
         if element.get("foreign_keys"):
             fk_tables = [fk.get("ref_table", "") for fk in element["foreign_keys"]]
             if fk_tables:
@@ -507,7 +509,6 @@ class SchemaEmbeddingManager:
         index_file = self.index_path / "schema_index.faiss"
         metadata_file = self.index_path / "schema_metadata.pkl"
 
-        # Save FAISS index
         faiss.write_index(self.index, str(index_file))
 
         # Load existing metadata to preserve fields managed by other components
@@ -519,7 +520,6 @@ class SchemaEmbeddingManager:
             except Exception:
                 pass
 
-        # Save metadata including provider information
         metadata = {
             "id_to_schema": self.id_to_schema,
             "schema_to_id": self.schema_to_id,
@@ -543,7 +543,6 @@ class SchemaEmbeddingManager:
 
     def _update_tfidf_index(self, new_texts: List[str]) -> None:
         """Update TF-IDF index with new texts."""
-        # Append new texts
         self.tfidf_texts.extend(new_texts)
 
         # Re-fit vectorizer on all texts
@@ -565,16 +564,13 @@ class SchemaEmbeddingManager:
         self.schema_to_id = {}
         self._next_id = 0
 
-        # Clear TF-IDF
         self.tfidf_vectorizer = None
         self.tfidf_matrix = None
         self.tfidf_texts = []
 
-        # Clear cache if available
         if self.cache:
             await self.cache.clear()
 
-        # Remove saved files
         index_file = self.index_path / "schema_index.faiss"
         metadata_file = self.index_path / "schema_metadata.pkl"
 

--- a/src/nlp2sql/schema/manager.py
+++ b/src/nlp2sql/schema/manager.py
@@ -4,6 +4,7 @@ import pickle
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional, Tuple
 
+import numpy as np
 import structlog
 
 from ..config.settings import settings
@@ -49,7 +50,6 @@ class SchemaManager:
         self.embedding_provider = embedding_provider
         self.schema_name = schema_name
 
-        # Create or use provided embedding manager
         if embedding_manager is None:
             self.embedding_manager = SchemaEmbeddingManager(
                 database_url=repository.database_url,
@@ -60,18 +60,15 @@ class SchemaManager:
         else:
             self.embedding_manager = embedding_manager
 
-        # Create or use provided analyzer
         if analyzer is None:
             self.analyzer = SchemaAnalyzer(embedding_provider=embedding_provider)
         else:
             self.analyzer = analyzer
 
-        # Configuration
         self.max_schema_tokens = settings.max_schema_tokens
         self.cache_enabled = settings.schema_cache_enabled
         self.refresh_interval = timedelta(hours=settings.schema_refresh_interval_hours)
 
-        # Schema filtering
         self.schema_filters = schema_filters or {}
         self.included_schemas = self.schema_filters.get("include_schemas", None)
         self.excluded_schemas = self.schema_filters.get("exclude_schemas", [])
@@ -79,12 +76,10 @@ class SchemaManager:
         self.excluded_tables = self.schema_filters.get("exclude_tables", [])
         self.exclude_system_tables = self.schema_filters.get("exclude_system_tables", True)
 
-        # Internal state
         self._last_refresh = None
         self._schema_cache = {}
         self._table_relevance_cache = {}
 
-        # Load refresh state early if index exists
         self._load_refresh_state_early()
 
     async def initialize(self, database_type: DatabaseType) -> None:
@@ -159,17 +154,14 @@ class SchemaManager:
         """Get optimal schema context for a query."""
         max_tokens = max_tokens or self.max_schema_tokens
 
-        # Check cache first
         cache_key = f"schema_context:{query}:{database_type.value}:{max_tokens}"
         if self.cache_enabled and self.cache:
             cached_context = await self.cache.get(cache_key)
             if cached_context:
                 return cached_context
 
-        # Find relevant tables using multiple strategies
         relevant_tables = await self._find_relevant_tables(query, database_type)
 
-        # Build context using analyzer
         context = SchemaContext(
             query=query,
             max_tokens=max_tokens,
@@ -178,7 +170,6 @@ class SchemaManager:
             include_indexes=True,
         )
 
-        # Get table details
         table_details = []
         for table_name, relevance_score in relevant_tables:
             try:
@@ -189,17 +180,13 @@ class SchemaManager:
             except Exception as e:
                 logger.warning("Failed to get table info", table=table_name, error=str(e))
 
-        # Build optimized context
         schema_context = await self.analyzer.build_context(context, table_details)
 
-        # Validate token count
         estimated_tokens = len(schema_context) // 4  # Rough estimation
         if estimated_tokens > max_tokens:
-            # Compress further
             schema_dict = {table["name"]: table for table in table_details}
             schema_context = await self.analyzer.compress_schema(schema_dict, max_tokens)
 
-        # Cache result
         if self.cache_enabled and self.cache:
             await self.cache.set(cache_key, schema_context)
 
@@ -271,7 +258,6 @@ class SchemaManager:
         self._last_refresh = datetime.now()
         self._save_refresh_state()
 
-        # Clear relevant caches
         if self.cache:
             # Clear schema-related cache keys
             pass  # Implementation depends on cache implementation
@@ -323,11 +309,11 @@ class SchemaManager:
                 return cached_tables
 
         # Strategy 1: Embedding similarity (uses FAISS index)
-        embedding_results = await self.embedding_manager.search_similar(
+        # Use search_similar_with_embedding to capture query_embedding for reuse downstream
+        embedding_results, query_embedding = await self.embedding_manager.search_similar_with_embedding(
             query, top_k=max_tables * 2, database_type=database_type
         )
 
-        # Filter to tables only
         table_scores = {}
         for element, score in embedding_results:
             if element.get("type") == "table":
@@ -339,7 +325,6 @@ class SchemaManager:
                     table_scores[table_name] = max(table_scores.get(table_name, 0), score * 0.8)
 
         # Strategy 2: Batch schema analysis
-        # Use cached tables (now fast with bulk query + disk cache)
         all_tables = await self._get_cached_tables()
 
         # Identify tables to analyze with batch scoring
@@ -366,9 +351,24 @@ class SchemaManager:
         if tables_to_analyze:
             table_dicts = [self._table_info_to_dict(t) for t in tables_to_analyze]
 
-            # Batch score all tables (uses single embedding API call)
+            # Fetch precomputed embeddings from FAISS for tables being analyzed (zero API calls)
+            table_names_to_analyze = [t.name for t in tables_to_analyze]
+            precomputed_element_embeddings = await self.embedding_manager.get_table_embeddings(
+                table_names_to_analyze, database_type
+            )
+
+            # Prepare query embedding for reuse (avoid redundant API call in analyzer)
+            precomputed_query_emb: Optional[np.ndarray] = None
+            if query_embedding.size > 0:
+                precomputed_query_emb = query_embedding
+
+            # Batch score all tables (uses precomputed embeddings — zero additional API calls)
             scored_tables = await self.analyzer.score_relevance_batch(
-                query, table_dicts, use_semantic=True
+                query,
+                table_dicts,
+                use_semantic=True,
+                precomputed_query_embedding=precomputed_query_emb,
+                precomputed_element_embeddings=precomputed_element_embeddings if precomputed_element_embeddings else None,
             )
 
             for table_dict, score in scored_tables:
@@ -380,14 +380,12 @@ class SchemaManager:
         exact_matches = [(name, score) for name, score in table_scores.items() if score >= 1.0]
         other_matches = [(name, score) for name, score in table_scores.items() if score < 1.0]
 
-        # Sort each group by score
         exact_matches.sort(key=lambda x: x[1], reverse=True)
         other_matches.sort(key=lambda x: x[1], reverse=True)
 
         # Combine: exact matches first, then others
         sorted_tables = exact_matches + other_matches
 
-        # Apply minimum threshold and limit
         relevant_tables = []
         for table_name, score in sorted_tables:
             if score >= 0.2 and len(relevant_tables) < max_tables:
@@ -396,7 +394,6 @@ class SchemaManager:
         # Store in memory cache (always enabled, for repeated queries in same session)
         self._table_relevance_cache[mem_cache_key] = relevant_tables
 
-        # Also cache in external cache if available
         if self.cache_enabled and self.cache:
             await self.cache.set(cache_key, relevant_tables)
 
@@ -512,7 +509,6 @@ class SchemaManager:
             elif "." in table.name:
                 schema_name = table.name.split(".")[0]
 
-            # Check schema-level filters
             if self.included_schemas is not None:
                 if schema_name not in self.included_schemas:
                     continue
@@ -520,7 +516,6 @@ class SchemaManager:
             if schema_name in self.excluded_schemas:
                 continue
 
-            # Check table-level filters
             if self.included_tables is not None:
                 if table.name not in self.included_tables:
                     continue
@@ -528,9 +523,7 @@ class SchemaManager:
             if table.name in self.excluded_tables:
                 continue
 
-            # Check system table filter
             if self.exclude_system_tables:
-                # Common system table patterns
                 system_patterns = [
                     "pg_",
                     "sql_",

--- a/tests/test_batch_scoring.py
+++ b/tests/test_batch_scoring.py
@@ -379,6 +379,135 @@ class TestQueryEmbeddingCache:
         assert len(analyzer._query_embedding_cache) == 0
 
 
+class TestPrecomputedEmbeddings:
+    """Test precomputed embedding parameters in score_relevance_batch and _calculate_semantic_similarity_batch."""
+
+    @pytest.fixture
+    def mock_embedding_provider(self):
+        """Create a mock embedding provider."""
+        provider = MagicMock()
+        provider.encode = AsyncMock(
+            side_effect=lambda texts: np.random.rand(len(texts), 384)
+        )
+        return provider
+
+    @pytest.fixture
+    def analyzer(self, mock_embedding_provider):
+        """Create analyzer with mock provider."""
+        return SchemaAnalyzer(embedding_provider=mock_embedding_provider)
+
+    @pytest.fixture
+    def sample_tables(self) -> List[Dict[str, Any]]:
+        """Sample table elements."""
+        return [
+            {
+                "name": "users",
+                "type": "table",
+                "columns": [{"name": "id"}, {"name": "email"}],
+            },
+            {
+                "name": "orders",
+                "type": "table",
+                "columns": [{"name": "id"}, {"name": "total"}],
+            },
+            {
+                "name": "products",
+                "type": "table",
+                "columns": [{"name": "id"}, {"name": "name"}],
+            },
+        ]
+
+    @pytest.mark.asyncio
+    async def test_precomputed_both_skips_all_api_calls(self, analyzer, mock_embedding_provider, sample_tables):
+        """Verify zero encode() calls when both query and element embeddings are precomputed."""
+        mock_embedding_provider.encode.reset_mock()
+
+        # Precompute embeddings
+        query_embedding = np.random.rand(1, 384).astype(np.float32)
+        element_embeddings = {
+            "users": np.random.rand(384).astype(np.float32),
+            "orders": np.random.rand(384).astype(np.float32),
+            "products": np.random.rand(384).astype(np.float32),
+        }
+
+        result = await analyzer.score_relevance_batch(
+            "find customer data",
+            sample_tables,
+            use_semantic=True,
+            precomputed_query_embedding=query_embedding,
+            precomputed_element_embeddings=element_embeddings,
+        )
+
+        # All 3 tables returned
+        assert len(result) == 3
+        # Zero API calls since everything was precomputed
+        mock_embedding_provider.encode.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_partial_precomputed_element_embeddings(self, analyzer, mock_embedding_provider, sample_tables):
+        """Verify only missing elements trigger API calls."""
+        mock_embedding_provider.encode.reset_mock()
+
+        query_embedding = np.random.rand(1, 384).astype(np.float32)
+        # Only precompute 2 of 3 table embeddings
+        element_embeddings = {
+            "users": np.random.rand(384).astype(np.float32),
+            "orders": np.random.rand(384).astype(np.float32),
+            # "products" is missing — should trigger API call
+        }
+
+        result = await analyzer.score_relevance_batch(
+            "find customer data",
+            sample_tables,
+            use_semantic=True,
+            precomputed_query_embedding=query_embedding,
+            precomputed_element_embeddings=element_embeddings,
+        )
+
+        assert len(result) == 3
+        # Should have exactly 1 API call for the missing "products" element
+        assert mock_embedding_provider.encode.call_count == 1
+        # The single call should be for 1 element description
+        call_args = mock_embedding_provider.encode.call_args[0][0]
+        assert len(call_args) == 1
+
+    @pytest.mark.asyncio
+    async def test_empty_precomputed_falls_back(self, analyzer, mock_embedding_provider, sample_tables):
+        """Verify np.array([]) falls back to original behavior (cache/API)."""
+        mock_embedding_provider.encode.reset_mock()
+
+        # Pass empty array as precomputed query embedding
+        empty_embedding = np.array([])
+
+        result = await analyzer.score_relevance_batch(
+            "find customer data",
+            sample_tables,
+            use_semantic=True,
+            precomputed_query_embedding=empty_embedding,
+            precomputed_element_embeddings=None,
+        )
+
+        assert len(result) == 3
+        # Should have made API calls: 1 for query + 1 for elements batch
+        assert mock_embedding_provider.encode.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_backward_compatibility_without_precomputed(self, analyzer, mock_embedding_provider, sample_tables):
+        """Verify original behavior when no precomputed args are passed."""
+        mock_embedding_provider.encode.reset_mock()
+
+        # Call without any precomputed args (original API)
+        result = await analyzer.score_relevance_batch(
+            "find customer data",
+            sample_tables,
+            use_semantic=True,
+        )
+
+        assert len(result) == 3
+        # Should make API calls as before (query + elements)
+        assert mock_embedding_provider.encode.call_count == 2
+
+
 class TestIntegrationWithSchemaManager:
     """Integration tests for batch scoring with SchemaManager patterns."""
 
@@ -489,3 +618,121 @@ class TestIntegrationWithSchemaManager:
         assert len(result) == 100
         # Should be very fast without API calls (< 1 second)
         assert elapsed < 1.0
+
+
+class TestBuildContextReusesScores:
+    """Test that build_context() reuses pre-computed relevance_score from SchemaManager."""
+
+    @pytest.fixture
+    def mock_embedding_provider(self):
+        """Create a mock embedding provider."""
+        provider = MagicMock()
+        provider.encode = AsyncMock(
+            side_effect=lambda texts: np.random.rand(len(texts), 384)
+        )
+        return provider
+
+    @pytest.fixture
+    def analyzer_with_provider(self, mock_embedding_provider):
+        """Create analyzer with embedding provider."""
+        return SchemaAnalyzer(embedding_provider=mock_embedding_provider)
+
+    @pytest.fixture
+    def schema_context(self):
+        """Create a SchemaContext for build_context calls."""
+        from nlp2sql.ports.schema_strategy import SchemaContext
+        return SchemaContext(
+            query="show me all orders",
+            max_tokens=4000,
+            database_type="postgresql",
+            include_samples=False,
+            include_indexes=False,
+        )
+
+    @pytest.mark.asyncio
+    async def test_build_context_uses_existing_relevance_score(
+        self, analyzer_with_provider, mock_embedding_provider, schema_context
+    ):
+        """Tables with relevance_score key skip score_relevance() entirely, zero encode() calls."""
+        mock_embedding_provider.encode.reset_mock()
+
+        tables = [
+            {
+                "name": "orders",
+                "type": "table",
+                "relevance_score": 0.95,
+                "columns": [
+                    {"name": "id", "type": "integer"},
+                    {"name": "total", "type": "decimal"},
+                ],
+            },
+            {
+                "name": "users",
+                "type": "table",
+                "relevance_score": 0.7,
+                "columns": [
+                    {"name": "id", "type": "integer"},
+                    {"name": "name", "type": "varchar"},
+                ],
+            },
+        ]
+
+        result = await analyzer_with_provider.build_context(schema_context, tables)
+
+        # Should produce valid context output
+        assert "orders" in result
+        # Zero embedding API calls since all tables had pre-computed scores
+        mock_embedding_provider.encode.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_build_context_falls_back_without_relevance_score(
+        self, analyzer_with_provider, mock_embedding_provider, schema_context
+    ):
+        """Tables without the relevance_score key still call score_relevance() (backward compat)."""
+        mock_embedding_provider.encode.reset_mock()
+
+        tables = [
+            {
+                "name": "orders",
+                "type": "table",
+                "columns": [
+                    {"name": "id", "type": "integer"},
+                    {"name": "total", "type": "decimal"},
+                ],
+            },
+        ]
+
+        result = await analyzer_with_provider.build_context(schema_context, tables)
+
+        # Should still produce valid context
+        assert "orders" in result
+        # Should have called encode() since score_relevance() was used
+        mock_embedding_provider.encode.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_build_context_mixed_tables(
+        self, analyzer_with_provider, mock_embedding_provider, schema_context
+    ):
+        """Only tables missing relevance_score trigger scoring; pre-scored ones don't."""
+        mock_embedding_provider.encode.reset_mock()
+
+        tables = [
+            {
+                "name": "orders",
+                "type": "table",
+                "relevance_score": 0.95,
+                "columns": [{"name": "id", "type": "integer"}],
+            },
+            {
+                "name": "unscored_table",
+                "type": "table",
+                "columns": [{"name": "id", "type": "integer"}],
+            },
+        ]
+
+        result = await analyzer_with_provider.build_context(schema_context, tables)
+
+        # orders should appear (high pre-computed score)
+        assert "orders" in result
+        # encode() should have been called for unscored_table's score_relevance()
+        mock_embedding_provider.encode.assert_called()

--- a/tests/test_embedding_manager.py
+++ b/tests/test_embedding_manager.py
@@ -192,6 +192,81 @@ class TestOrphanMappingsPrevention:
             assert embedding.shape == (provider.dimension,)
 
 
+class TestSearchSimilarWithEmbedding:
+    """Tests for search_similar_with_embedding() method."""
+
+    @pytest.fixture
+    def temp_index_path(self, tmp_path):
+        return tmp_path / "test_embeddings"
+
+    @pytest.mark.asyncio
+    async def test_returns_query_embedding(self, temp_index_path):
+        """Test that search_similar_with_embedding returns (results, np.ndarray)."""
+        provider = MockEmbeddingProvider()
+
+        manager = SchemaEmbeddingManager(
+            database_url="postgresql://test:test@localhost/test",
+            embedding_provider=provider,
+            index_path=temp_index_path,
+        )
+
+        # Add elements so search has something to find
+        elements = [
+            {"type": "table", "name": "users", "columns": [{"name": "id"}]},
+            {"type": "table", "name": "orders", "columns": [{"name": "id"}]},
+        ]
+        await manager.add_schema_elements(elements, DatabaseType.POSTGRES)
+
+        results, query_embedding = await manager.search_similar_with_embedding(
+            "show users", database_type=DatabaseType.POSTGRES
+        )
+
+        # Results should be a list of (element, score) tuples
+        assert isinstance(results, list)
+        # Query embedding should be a numpy array with correct dimension
+        assert isinstance(query_embedding, np.ndarray)
+        assert query_embedding.size > 0
+        assert query_embedding.shape[-1] == provider.dimension
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_embedding_without_provider(self, temp_index_path):
+        """Test that ([], np.array([])) is returned when no provider is configured."""
+        manager = SchemaEmbeddingManager(
+            database_url="postgresql://test:test@localhost/test",
+            embedding_provider=None,
+            index_path=temp_index_path,
+        )
+
+        results, query_embedding = await manager.search_similar_with_embedding("users")
+
+        assert results == []
+        assert isinstance(query_embedding, np.ndarray)
+        assert query_embedding.size == 0
+
+    @pytest.mark.asyncio
+    async def test_search_similar_unchanged(self, temp_index_path):
+        """Test that search_similar() still returns List[Tuple] (not a tuple)."""
+        provider = MockEmbeddingProvider()
+
+        manager = SchemaEmbeddingManager(
+            database_url="postgresql://test:test@localhost/test",
+            embedding_provider=provider,
+            index_path=temp_index_path,
+        )
+
+        elements = [{"type": "table", "name": "users", "columns": [{"name": "id"}]}]
+        await manager.add_schema_elements(elements, DatabaseType.POSTGRES)
+
+        results = await manager.search_similar("users", database_type=DatabaseType.POSTGRES)
+
+        # search_similar should return a plain list, NOT a tuple
+        assert isinstance(results, list)
+        # Should not accidentally return (results, embedding) tuple
+        if results:
+            assert isinstance(results[0], tuple)
+            assert len(results[0]) == 2  # (element, score)
+
+
 class TestEmbeddingManagerWithoutProvider:
     """Tests for SchemaEmbeddingManager when no provider is configured."""
 


### PR DESCRIPTION
## Description

Optimize the schema relevance pipeline to reduce embedding API calls from ~18 to ~1 per query. Batch scoring with precomputed embeddings eliminates N+1 API calls in `_find_relevant_tables()`, and score reuse in `build_context()` eliminates ~10-15 redundant per-table embedding calls. Also enhances documentation and cleans ~84 redundant comments across the schema module.

### API Call Reduction

| Stage | Before | After |
|-------|--------|-------|
| `_find_relevant_tables` | ~3 calls + ~14 element embeds | **1 call** |
| `build_context` | ~10-15 calls (1/table) | **0 calls** |
| **Total per query** | **~18 calls** | **~1 call** |

## Type of Change
- [ ] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [x] Documentation update

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed
- [x] All tests pass

### Test Commands
- [ ] `uv run pytest tests/test_batch_scoring.py -v` — all 28 tests pass
- [ ] `uv run pytest tests/test_embedding_manager.py -v` — all 8 tests pass
- [ ] `uv run pytest -m "not integration" -v` — all 143 tests pass
- [ ] `uv run ruff check src/nlp2sql/schema/` — no new lint issues
- [ ] Manual test with `examples/redshift_trafilea_demo.py` — verify ~1 embedding call per query

## Checklist
- [x] Code follows style guidelines
- [x] Self-review completed
- [x] Documentation updated
- [x] No new warnings introduced

Closes #27