### PR TITLE
feat: add semantic context and SQL intent planning to the generation pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,30 +9,41 @@
   <a href="https://github.com/psf/black"><img src="https://img.shields.io/badge/code%20style-black-000000.svg" alt="Code style: black"></a>
 </p>
 
-# nlp2sql 
+# nlp2sql
 
-**Enterprise-ready Natural Language to SQL converter with multi-provider support**
+**DSL-first natural language to SQL for PostgreSQL and Redshift**
 
-Convert natural language queries to optimized SQL using multiple AI providers. Built with Clean Architecture principles for enterprise-scale applications handling 1000+ table databases.
+`nlp2sql` turns a natural language question into SQL through a reusable Python DSL:
+
+- `await connect(...)`
+- `await nlp.ask(...)`
+- optional few-shot examples
+- optional semantic context
+- optional validation and repair
+
+The library is designed for both simple schemas and large warehouses, but all public examples in this repository use the local e-commerce domain shipped with the project itself.
 
 ## Features
 
-- **Multiple AI Providers**: OpenAI, Anthropic Claude, Google Gemini - no vendor lock-in
-- **Database Support**: PostgreSQL, Amazon Redshift
-- **Large Schema Handling**: Vector embeddings and intelligent filtering for 1000+ tables
-- **Smart Caching**: Query and schema embedding caching for improved performance
-- **Async Support**: Full async/await support
-- **Clean Architecture**: Ports & Adapters pattern for maintainability
+- **DSL-first API**: `connect()` returns an `NLP2SQL` client with `ask()`, `validate()`, `explain()`, and `suggest()`
+- **Business-aware generation**: optional `SemanticContext` adds canonical tables, metrics, dimensions, rules, and mappings
+- **Execution modes**: generate only, generate plus validate, and generate plus validate plus repair
+- **Few-shot examples**: pass example lists directly or use an example repository implementation
+- **Large schema support**: FAISS plus TF-IDF hybrid retrieval, schema filters, and disk-backed caches
+- **Multiple providers**: OpenAI, Anthropic, and Gemini
+- **Database support**: PostgreSQL and Amazon Redshift
+- **Async by default**: built for services, APIs, notebooks, and workers
 
 ## Documentation
 
 | Document | Description |
 |----------|-------------|
-| [Architecture](docs/ARCHITECTURE.md) | Component diagram and data flow |
-| [API Reference](docs/API.md) | Python API and CLI command reference |
-| [Configuration](docs/CONFIGURATION.md) | Environment variables and schema filters |
-| [Enterprise Guide](docs/ENTERPRISE.md) | Large-scale deployment and migration |
-| [Redshift Support](docs/Redshift.md) | Amazon Redshift setup and examples |
+| [Architecture](docs/ARCHITECTURE.md) | Runtime flow, services, ports, and diagrams |
+| [API Reference](docs/API.md) | Python API, CLI, hooks, and metadata reference |
+| [Configuration](docs/CONFIGURATION.md) | Environment variables, examples, semantic context, cache behavior |
+| [Enterprise Guide](docs/ENTERPRISE.md) | Governed usage, scale, and deployment patterns |
+| [Redshift Support](docs/Redshift.md) | Redshift-specific notes using public examples |
+| [Examples](examples/README.md) | Safe public examples based on the local e-commerce domain |
 | [Contributing](CONTRIBUTING.md) | Contribution guidelines |
 
 ## Installation
@@ -49,188 +60,259 @@ pip install nlp2sql[anthropic,gemini]
 pip install nlp2sql[all-providers]
 
 # With embeddings
-pip install nlp2sql[embeddings-local]   # Local embeddings (free)
-pip install nlp2sql[embeddings-openai]  # OpenAI embeddings
+pip install nlp2sql[embeddings-local]
+pip install nlp2sql[embeddings-openai]
 ```
 
 ## Quick Start
 
-### 1. Set an API Key
+### 1. Set a Provider Key
 
 ```bash
 export OPENAI_API_KEY="your-openai-key"
-# or ANTHROPIC_API_KEY, GOOGLE_API_KEY
+# or ANTHROPIC_API_KEY / GOOGLE_API_KEY
 ```
 
-### 2. Connect and Ask
+### 2. Use the DSL
 
 ```python
 import asyncio
+
 import nlp2sql
 from nlp2sql import ProviderConfig
 
+
 async def main():
     nlp = await nlp2sql.connect(
-        "postgresql://user:pass@localhost:5432/mydb",
+        "postgresql://testuser:testpass@localhost:5432/testdb",
         provider=ProviderConfig(provider="openai", api_key="sk-..."),
     )
 
-    result = await nlp.ask("Show me all active users")
+    result = await nlp.ask("Show active users by region")
     print(result.sql)
     print(result.confidence)
-    print(result.is_valid)
+    print(result.metadata["sql_intent_plan"])
+
 
 asyncio.run(main())
 ```
 
-`connect()` auto-detects the database type from the URL, loads the schema, and builds the FAISS embedding index. Subsequent `ask()` calls reuse everything from disk cache.
+`connect()` loads the schema, initializes retrieval indexes, and returns a reusable `NLP2SQL` client. `ask()` returns a typed `QueryResult`.
 
-### 3. Few-Shot Examples
+### 3. Add Few-Shot Examples
 
-Pass a list of dicts -- `connect()` handles embedding and indexing automatically:
+Pass examples directly to `connect()`. The library handles indexing for you.
 
 ```python
 nlp = await nlp2sql.connect(
-    "redshift://user:pass@host:5439/db",
+    "postgresql://testuser:testpass@localhost:5432/testdb",
     provider=ProviderConfig(provider="openai", api_key="sk-..."),
-    schema="dwh_data_share_llm",
     examples=[
         {
-            "question": "Total revenue last month?",
-            "sql": "SELECT SUM(revenue) FROM sales WHERE date >= DATE_TRUNC('month', CURRENT_DATE - INTERVAL '1 month')",
-            "database_type": "redshift",
-        },
+            "question": "Show revenue by source category for the flagship store",
+            "sql": (
+                "SELECT d.metric_date, mc.source_category, SUM(d.revenue) AS revenue "
+                "FROM daily_channel_metrics d "
+                "JOIN stores s ON d.store_id = s.id "
+                "JOIN marketing_channels mc ON d.channel_id = mc.id "
+                "WHERE s.code = 'na_flagship' "
+                "GROUP BY d.metric_date, mc.source_category"
+            ),
+            "database_type": "postgres",
+        }
+    ],
+)
+```
+
+### 4. Add In-Memory Semantic Context
+
+Use semantic context when the same question could map to multiple plausible tables or dimensions.
+
+```python
+from nlp2sql import (
+    DimensionDefinition,
+    DomainRule,
+    MetricDefinition,
+    SemanticContext,
+    SemanticEntityMapping,
+)
+
+semantic_context = SemanticContext(
+    domain="ecommerce_channel_performance",
+    canonical_tables=["daily_channel_metrics"],
+    required_filters=["s.code = 'na_flagship'", "s.region = 'North America'"],
+    entity_mappings=[
+        SemanticEntityMapping(
+            source_term="North America flagship store",
+            target="store_scope",
+            resolved_value="na_flagship / North America",
+            filter_expression="s.code = 'na_flagship' AND s.region = 'North America'",
+        )
+    ],
+    metric_definitions=[
+        MetricDefinition(name="revenue", description="Revenue by day and source category."),
+        MetricDefinition(name="orders_count", description="Orders by day and source category."),
+    ],
+    dimension_definitions=[
+        DimensionDefinition(name="metric_date", description="Daily grain."),
+        DimensionDefinition(name="source_category", description="Channel grouping."),
+    ],
+    rules=[
+        DomainRule(
+            name="preserve_source_breakdown",
+            description="Keep source_category when the question asks for a source breakdown.",
+            required_dimensions=["source_category"],
+            preferred_tables=["daily_channel_metrics"],
+        )
     ],
 )
 
-result = await nlp.ask("Show me total sales this quarter")
-```
-
-### 4. Schema Filtering (Large Databases)
-
-```python
-nlp = await nlp2sql.connect(
-    "postgresql://localhost/enterprise",
-    provider=ProviderConfig(provider="anthropic", api_key="sk-ant-..."),
-    schema_filters={
-        "include_schemas": ["sales", "finance"],
-        "exclude_system_tables": True,
-    },
+result = await nlp.ask(
+    "Show daily revenue and order count by source category for the North America flagship store",
+    semantic_context=semantic_context,
 )
 ```
 
-### 5. Custom Model and Temperature
+### 5. Validate and Repair
+
+`ask()` supports execution-aware modes directly.
 
 ```python
-nlp = await nlp2sql.connect(
-    "postgresql://localhost/mydb",
-    provider=ProviderConfig(
-        provider="openai",
-        api_key="sk-...",
-        model="gpt-4o",
-        temperature=0.0,
-        max_tokens=4000,
-    ),
+result = await nlp.ask(
+    "Show revenue by source category for the flagship store",
+    validate=True,
+    repair=True,
 )
 ```
 
-### 6. CLI
+- `generate_only`: generate SQL only
+- `generate_and_validate`: execute readonly validation when execution is wired
+- `generate_validate_repair`: retry on semantic or execution failures when repair hooks are available
+
+### 6. CLI Parity
+
+The CLI exposes the same concepts:
 
 ```bash
 nlp2sql query \
-  --database-url postgresql://user:pass@localhost:5432/mydb \
-  --question "Show all active users" \
-  --explain
-
-nlp2sql inspect --database-url postgresql://localhost/mydb
-```
-
-### Advanced: Direct Service Access
-
-For full control over the lifecycle, the lower-level API is still available:
-
-```python
-from nlp2sql import create_and_initialize_service, ProviderConfig, DatabaseType
-
-service = await create_and_initialize_service(
-    database_url="postgresql://localhost/mydb",
-    provider_config=ProviderConfig(provider="openai", api_key="sk-..."),
-    database_type=DatabaseType.POSTGRES,
-)
-result = await service.generate_sql("Count total users", database_type=DatabaseType.POSTGRES)
+  --database-url postgresql://testuser:testpass@localhost:5432/testdb \
+  --question "Show daily revenue by source category for the North America flagship store" \
+  --examples-file examples.json \
+  --semantic-context-file semantic-context.json \
+  --validate \
+  --repair \
+  --show-semantic-context \
+  --show-sql-intent-plan \
+  --show-selected-examples
 ```
 
 ## How It Works
 
-```
-Question ──► Cache check ──► Schema retrieval ──► Relevance filtering ──► Context building ──► AI generation ──► Validation
-                                    │                     │                      │
-                              SchemaRepository    FAISS + TF-IDF hybrid   Reuses precomputed
-                              (+ disk cache)      + batch scoring          relevance scores
+```mermaid
+flowchart TD
+    userCode[UserCodeOrCLI] --> dsl[connectAndAskDSL]
+    dsl --> analysis[QueryAnalysisService]
+    analysis --> semantic[SemanticResolutionService]
+    semantic --> retrieval[SchemaRetrievalAndExampleSelection]
+    retrieval --> intent[SqlIntentPlanningService]
+    intent --> prompt[PromptAssemblyAndAdapters]
+    prompt --> llm[LLMGeneration]
+    llm --> semval[SemanticValidation]
+    semval --> exec[OptionalExecutionAndRepair]
+    exec --> result[QueryResultMetadata]
 ```
 
-1. **Schema retrieval** -- Fetches tables from database via `SchemaRepository` (with disk cache for Redshift)
-2. **Relevance filtering** -- FAISS dense search + TF-IDF sparse search (50/50 hybrid) finds candidate tables; batch scoring refines with precomputed embeddings
-3. **Context building** -- Builds optimized schema context within token limits, reusing scores from step 2 (zero additional embedding calls)
-4. **SQL generation** -- AI provider (OpenAI, Anthropic, or Gemini) generates SQL from question + schema context
-5. **Validation** -- SQL syntax and safety checks before returning results
+At runtime the library:
 
-See [Architecture](docs/ARCHITECTURE.md) for the detailed flow with method references and design decisions.
+1. analyzes the question
+2. optionally resolves and merges semantic context
+3. retrieves relevant schema and examples
+4. builds a structured SQL intent plan
+5. assembles the prompt
+6. generates SQL
+7. optionally validates, executes, and repairs
+8. returns a `QueryResult` with debug metadata
+
+See [Architecture](docs/ARCHITECTURE.md) for the full breakdown.
+
+## Public Example Domain
+
+This repository ships a local e-commerce integration domain used in tests and docs. It includes:
+
+- `stores`
+- `marketing_channels`
+- `users`
+- `products`
+- `orders`
+- `order_items`
+- `daily_channel_metrics`
+
+The public examples intentionally stay inside that domain to avoid leaking any private warehouse schema.
+
+To start it locally:
+
+```bash
+cd docker
+docker compose up -d postgres
+```
+
+The default URL is:
+
+```bash
+postgresql://testuser:testpass@localhost:5432/testdb
+```
 
 ## Provider Comparison
 
 | Provider | Default Model | Context Size | Best For |
-|----------|--------------|-------------|----------|
-| OpenAI | gpt-4o-mini | 128K | Cost-effective, fast |
-| Anthropic | claude-sonnet-4-20250514 | 200K | Large schemas |
-| Google Gemini | gemini-2.0-flash | 1M | High volume |
+|----------|---------------|--------------|----------|
+| OpenAI | `gpt-4o-mini` | 128K | Fast general purpose usage |
+| Anthropic | `claude-sonnet-4-20250514` | 200K | Larger schemas and long prompts |
+| Gemini | `gemini-2.0-flash` | 1M | High-volume and very large contexts |
 
-All models are configurable via `ProviderConfig(model="...")`. See [Configuration](docs/CONFIGURATION.md) for details.
+All models are configurable through `ProviderConfig`.
 
-## Architecture
+## Lower-Level API
 
-Clean Architecture (Ports & Adapters) with three layers: core entities, port interfaces, and adapter implementations. The schema management layer uses FAISS + TF-IDF hybrid search for relevance filtering at scale.
+`connect()` is the recommended path. Lower-level entry points still exist for advanced wiring:
 
+```python
+from nlp2sql import DatabaseType, ProviderConfig, create_and_initialize_service
+
+service = await create_and_initialize_service(
+    database_url="postgresql://testuser:testpass@localhost:5432/testdb",
+    provider_config=ProviderConfig(provider="openai", api_key="sk-..."),
+    database_type=DatabaseType.POSTGRES,
+)
+
+result = await service.generate_sql(
+    "Count active users by region",
+    database_type=DatabaseType.POSTGRES,
+)
+print(result["sql"])
 ```
-nlp2sql/
-├── client.py       # DSL: connect() + NLP2SQL class (recommended entry point)
-├── core/           # Pure Python: entities, ProviderConfig, QueryResult, sql_safety, sql_keywords
-├── ports/          # Interfaces: AIProviderPort, SchemaRepositoryPort, EmbeddingProviderPort,
-│                   #   ExampleRepositoryPort, QuerySafetyPort, QueryValidatorPort, CachePort
-├── adapters/       # Implementations: OpenAI, Anthropic, Gemini, PostgreSQL, Redshift,
-│                   #   RegexQueryValidator
-├── services/       # Orchestration: QueryGenerationService
-├── schema/         # Schema management: SchemaManager, SchemaAnalyzer, SchemaEmbeddingManager,
-│                   #   ExampleStore
-├── config/         # Pydantic Settings (centralized defaults)
-└── exceptions/     # Exception hierarchy (NLP2SQLException -> 8 subclasses)
-```
-
-See [Architecture](docs/ARCHITECTURE.md) for the full component diagram, data flow, and design decisions.
 
 ## Development
 
 ```bash
-# Clone and install
 git clone https://github.com/luiscarbonel1991/nlp2sql.git
 cd nlp2sql
 uv sync
 
-# Start test databases
-cd docker && docker-compose up -d
+# Start the local public e-commerce database
+cd docker && docker compose up -d postgres
 
-# Run tests
-uv run pytest
+# Integration tests without llm
+cd ..
+uv run pytest -m "integration and not llm"
 
-# Code quality
-uv run ruff format .
-uv run ruff check .
-uv run mypy src/
+# Optional llm integration tests
+uv run pytest -m "integration and llm"
 ```
 
 ## MCP Server
 
-nlp2sql includes a Model Context Protocol server for AI assistant integration.
+`nlp2sql` includes a Model Context Protocol server for assistant integration.
 
 ```json
 {
@@ -240,25 +322,19 @@ nlp2sql includes a Model Context Protocol server for AI assistant integration.
       "args": ["/path/to/nlp2sql/mcp_server/server.py"],
       "env": {
         "OPENAI_API_KEY": "${OPENAI_API_KEY}",
-        "NLP2SQL_DEFAULT_DB_URL": "postgresql://user:pass@localhost:5432/mydb"
+        "NLP2SQL_DEFAULT_DB_URL": "postgresql://testuser:testpass@localhost:5432/testdb"
       }
     }
   }
 }
 ```
 
-Tools: `ask_database`, `explore_schema`, `run_sql`, `list_databases`, `explain_sql`
-
-See [mcp_server/README.md](mcp_server/README.md) for complete setup.
+See [mcp_server/README.md](mcp_server/README.md) for details.
 
 ## Contributing
 
-We welcome contributions. See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
+See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## License
 
-MIT License - see [LICENSE](LICENSE).
-
-## Author
-
-**Luis Carbonel** - [@luiscarbonel1991](https://github.com/luiscarbonel1991)
+MIT License. See [LICENSE](LICENSE).

--- a/docker/init-schema.sql
+++ b/docker/init-schema.sql
@@ -1,5 +1,28 @@
 -- nlp2sql Test Database Schema
--- Simple e-commerce example for testing SQL generation
+-- Expanded e-commerce example for local integration and semantic validation
+
+-- Store dimension
+CREATE TABLE stores (
+    id SERIAL PRIMARY KEY,
+    code VARCHAR(50) UNIQUE NOT NULL,
+    domain VARCHAR(120) UNIQUE NOT NULL,
+    name VARCHAR(150) NOT NULL,
+    region VARCHAR(100) NOT NULL,
+    country VARCHAR(100) NOT NULL,
+    currency VARCHAR(10) NOT NULL,
+    is_active BOOLEAN DEFAULT true,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Marketing channel dimension
+CREATE TABLE marketing_channels (
+    id SERIAL PRIMARY KEY,
+    channel_name VARCHAR(100) NOT NULL,
+    source_category VARCHAR(100) NOT NULL,
+    traffic_type VARCHAR(50) NOT NULL,
+    is_paid BOOLEAN DEFAULT false,
+    is_active BOOLEAN DEFAULT true
+);
 
 -- Users table
 CREATE TABLE users (
@@ -12,7 +35,10 @@ CREATE TABLE users (
     last_login TIMESTAMP,
     is_active BOOLEAN DEFAULT true,
     city VARCHAR(100),
-    country VARCHAR(100)
+    country VARCHAR(100),
+    region VARCHAR(100),
+    customer_segment VARCHAR(50) DEFAULT 'standard',
+    preferred_store_id INTEGER REFERENCES stores(id)
 );
 
 -- Categories table
@@ -29,6 +55,8 @@ CREATE TABLE products (
     id SERIAL PRIMARY KEY,
     name VARCHAR(200) NOT NULL,
     description TEXT,
+    brand VARCHAR(100) NOT NULL,
+    product_line VARCHAR(100),
     price DECIMAL(10,2) NOT NULL,
     category_id INTEGER REFERENCES categories(id),
     stock_quantity INTEGER DEFAULT 0,
@@ -42,11 +70,15 @@ CREATE TABLE products (
 CREATE TABLE orders (
     id SERIAL PRIMARY KEY,
     user_id INTEGER REFERENCES users(id),
+    store_id INTEGER REFERENCES stores(id),
+    channel_id INTEGER REFERENCES marketing_channels(id),
     total_amount DECIMAL(10,2) NOT NULL,
+    discount_amount DECIMAL(10,2) DEFAULT 0,
     status VARCHAR(20) DEFAULT 'pending',
     order_date TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     shipping_address TEXT,
     payment_method VARCHAR(50),
+    promo_code VARCHAR(50),
     notes TEXT
 );
 
@@ -72,14 +104,48 @@ CREATE TABLE reviews (
     is_verified BOOLEAN DEFAULT false
 );
 
--- Insert sample data
-INSERT INTO users (email, first_name, last_name, phone, city, country, is_active) VALUES
-('john.doe@email.com', 'John', 'Doe', '+1234567890', 'New York', 'USA', true),
-('jane.smith@email.com', 'Jane', 'Smith', '+1234567891', 'London', 'UK', true),
-('carlos.garcia@email.com', 'Carlos', 'Garcia', '+1234567892', 'Madrid', 'Spain', true),
-('anna.muller@email.com', 'Anna', 'Muller', '+1234567893', 'Berlin', 'Germany', true),
-('mike.johnson@email.com', 'Mike', 'Johnson', '+1234567894', 'Toronto', 'Canada', false);
+-- Daily aggregate table used to test business-aware table selection
+CREATE TABLE daily_channel_metrics (
+    metric_date DATE NOT NULL,
+    store_id INTEGER REFERENCES stores(id),
+    channel_id INTEGER REFERENCES marketing_channels(id),
+    sessions INTEGER NOT NULL,
+    add_to_cart_sessions INTEGER NOT NULL,
+    checkout_sessions INTEGER NOT NULL,
+    orders_count INTEGER NOT NULL,
+    revenue DECIMAL(10,2) NOT NULL,
+    PRIMARY KEY (metric_date, store_id, channel_id)
+);
 
+-- Seed stores
+INSERT INTO stores (code, domain, name, region, country, currency, is_active) VALUES
+('na_flagship', 'demo-flagship.com', 'Demo Flagship', 'North America', 'United States', 'USD', true),
+('eu_boutique', 'demo-boutique.eu', 'Demo Boutique Europe', 'Europe', 'Germany', 'EUR', true),
+('ca_outlet', 'demo-outlet.ca', 'Demo Outlet Canada', 'North America', 'Canada', 'CAD', true);
+
+-- Seed channels
+INSERT INTO marketing_channels (channel_name, source_category, traffic_type, is_paid, is_active) VALUES
+('Email', 'Email', 'owned', false, true),
+('Organic Search', 'Organic Search', 'organic', false, true),
+('Paid Search', 'Paid Search', 'paid', true, true),
+('Paid Social', 'Paid Social', 'paid', true, true),
+('Affiliate', 'Affiliate', 'partner', false, true);
+
+-- Seed users
+INSERT INTO users (
+    email, first_name, last_name, phone, city, country, region,
+    is_active, customer_segment, preferred_store_id
+) VALUES
+('john.doe@email.com', 'John', 'Doe', '+1234567890', 'New York', 'United States', 'North America', true, 'vip', 1),
+('jane.smith@email.com', 'Jane', 'Smith', '+1234567891', 'Berlin', 'Germany', 'Europe', true, 'standard', 2),
+('carlos.garcia@email.com', 'Carlos', 'Garcia', '+1234567892', 'Toronto', 'Canada', 'North America', true, 'growth', 3),
+('anna.muller@email.com', 'Anna', 'Muller', '+1234567893', 'Munich', 'Germany', 'Europe', true, 'vip', 2),
+('mike.johnson@email.com', 'Mike', 'Johnson', '+1234567894', 'Chicago', 'United States', 'North America', false, 'standard', 1),
+('lisa.wong@email.com', 'Lisa', 'Wong', '+1234567895', 'Vancouver', 'Canada', 'North America', true, 'growth', 3),
+('omar.hassan@email.com', 'Omar', 'Hassan', '+1234567896', 'Austin', 'United States', 'North America', true, 'vip', 1),
+('sofia.rossi@email.com', 'Sofia', 'Rossi', '+1234567897', 'Hamburg', 'Germany', 'Europe', true, 'standard', 2);
+
+-- Seed categories
 INSERT INTO categories (name, description, is_active) VALUES
 ('Electronics', 'Electronic devices and gadgets', true),
 ('Books', 'Physical and digital books', true),
@@ -87,26 +153,43 @@ INSERT INTO categories (name, description, is_active) VALUES
 ('Home & Garden', 'Home improvement and garden supplies', true),
 ('Sports', 'Sports equipment and accessories', true);
 
-INSERT INTO products (name, description, price, category_id, stock_quantity, sku, is_active) VALUES
-('Laptop Pro 15"', 'High-performance laptop for professionals', 1299.99, 1, 25, 'LAPTOP-PRO-15', true),
-('Wireless Headphones', 'Noise-cancelling wireless headphones', 299.99, 1, 50, 'WH-NC-001', true),
-('Programming Guide', 'Complete guide to modern programming', 49.99, 2, 100, 'BOOK-PROG-001', true),
-('Cotton T-Shirt', 'Comfortable cotton t-shirt', 19.99, 3, 200, 'TSHIRT-COT-001', true),
-('Running Shoes', 'Professional running shoes', 129.99, 5, 75, 'SHOES-RUN-001', true),
-('Garden Tool Set', 'Complete garden tool set', 89.99, 4, 30, 'GARDEN-TOOLS-001', true),
-('Smartphone', 'Latest smartphone with advanced features', 899.99, 1, 40, 'PHONE-ADV-001', true),
-('Cooking Book', 'International cooking recipes', 29.99, 2, 60, 'BOOK-COOK-001', true);
+-- Seed products
+INSERT INTO products (
+    name, description, brand, product_line, price, category_id,
+    stock_quantity, sku, is_active
+) VALUES
+('Laptop Pro 15"', 'High-performance laptop for professionals', 'Northwind', 'Pro Computing', 1299.99, 1, 25, 'LAPTOP-PRO-15', true),
+('Wireless Headphones', 'Noise-cancelling wireless headphones', 'Northwind', 'Audio Plus', 299.99, 1, 50, 'WH-NC-001', true),
+('Programming Guide', 'Complete guide to modern programming', 'PageTurner', 'Developer Library', 49.99, 2, 100, 'BOOK-PROG-001', true),
+('Cotton T-Shirt', 'Comfortable cotton t-shirt', 'Evergreen', 'Core Basics', 19.99, 3, 200, 'TSHIRT-COT-001', true),
+('Running Shoes', 'Professional running shoes', 'Evergreen', 'Motion', 129.99, 5, 75, 'SHOES-RUN-001', true),
+('Garden Tool Set', 'Complete garden tool set', 'HomeCraft', 'Outdoor Living', 89.99, 4, 30, 'GARDEN-TOOLS-001', true),
+('Smartphone', 'Latest smartphone with advanced features', 'Northwind', 'Mobile X', 899.99, 1, 40, 'PHONE-ADV-001', true),
+('Cooking Book', 'International cooking recipes', 'PageTurner', 'Kitchen Stories', 29.99, 2, 60, 'BOOK-COOK-001', true),
+('Fitness Tracker', 'Wearable tracker for active customers', 'Northwind', 'Motion', 199.99, 5, 90, 'TRACKER-FIT-001', true),
+('Premium Hoodie', 'Heavyweight premium hoodie', 'Evergreen', 'Core Basics', 59.99, 3, 120, 'HOODIE-PREM-001', true);
 
-INSERT INTO orders (user_id, total_amount, status, order_date, shipping_address, payment_method) VALUES
-(1, 1349.98, 'completed', '2024-01-15 10:30:00', '123 Main St, New York, NY', 'credit_card'),
-(2, 319.98, 'shipped', '2024-01-16 14:20:00', '456 Oak Ave, London, UK', 'paypal'),
-(3, 49.99, 'completed', '2024-01-17 09:15:00', '789 Pine St, Madrid, Spain', 'credit_card'),
-(1, 149.98, 'pending', '2024-01-18 16:45:00', '123 Main St, New York, NY', 'debit_card'),
-(4, 929.98, 'processing', '2024-01-19 11:30:00', '321 Elm St, Berlin, Germany', 'credit_card');
+-- Seed orders
+INSERT INTO orders (
+    user_id, store_id, channel_id, total_amount, discount_amount,
+    status, order_date, shipping_address, payment_method, promo_code
+) VALUES
+(1, 1, 3, 1349.98, 0.00, 'completed', '2024-01-15 10:30:00', '123 Main St, New York, NY', 'credit_card', NULL),
+(2, 2, 1, 319.98, 20.00, 'shipped', '2024-01-16 14:20:00', '456 Oak Ave, Berlin, Germany', 'paypal', 'WELCOME20'),
+(3, 3, 2, 49.99, 0.00, 'completed', '2024-01-17 09:15:00', '789 Pine St, Toronto, Canada', 'credit_card', NULL),
+(1, 1, 4, 149.98, 10.00, 'completed', '2024-01-18 16:45:00', '123 Main St, New York, NY', 'debit_card', 'SOCIAL10'),
+(4, 2, 3, 929.98, 0.00, 'processing', '2024-01-19 11:30:00', '321 Elm St, Munich, Germany', 'credit_card', NULL),
+(6, 3, 5, 219.98, 0.00, 'completed', '2024-01-19 18:20:00', '654 Queen St, Vancouver, Canada', 'credit_card', NULL),
+(7, 1, 2, 199.99, 0.00, 'completed', '2024-01-20 08:05:00', '987 Lake Ave, Austin, TX', 'paypal', NULL),
+(8, 2, 4, 79.98, 5.00, 'pending', '2024-01-20 12:10:00', '741 Birch Rd, Hamburg, Germany', 'credit_card', 'NEW5'),
+(1, 1, 1, 59.99, 0.00, 'completed', '2024-01-21 09:25:00', '123 Main St, New York, NY', 'credit_card', NULL),
+(3, 3, 2, 899.99, 50.00, 'completed', '2024-01-21 16:00:00', '789 Pine St, Toronto, Canada', 'bank_transfer', 'SEARCH50'),
+(2, 2, 3, 259.98, 0.00, 'completed', '2024-01-22 10:45:00', '456 Oak Ave, Berlin, Germany', 'credit_card', NULL),
+(7, 1, 4, 159.98, 0.00, 'completed', '2024-01-22 15:35:00', '987 Lake Ave, Austin, TX', 'paypal', NULL);
 
+-- Seed order items
 INSERT INTO order_items (order_id, product_id, quantity, unit_price, total_price) VALUES
 (1, 1, 1, 1299.99, 1299.99),
-(1, 4, 2, 19.99, 39.98),
 (1, 3, 1, 49.99, 49.99),
 (2, 2, 1, 299.99, 299.99),
 (2, 4, 1, 19.99, 19.99),
@@ -114,47 +197,117 @@ INSERT INTO order_items (order_id, product_id, quantity, unit_price, total_price
 (4, 5, 1, 129.99, 129.99),
 (4, 4, 1, 19.99, 19.99),
 (5, 7, 1, 899.99, 899.99),
-(5, 8, 1, 29.99, 29.99);
+(5, 8, 1, 29.99, 29.99),
+(6, 9, 1, 199.99, 199.99),
+(6, 8, 1, 29.99, 29.99),
+(7, 9, 1, 199.99, 199.99),
+(8, 4, 1, 19.99, 19.99),
+(8, 8, 2, 29.99, 59.98),
+(9, 10, 1, 59.99, 59.99),
+(10, 7, 1, 899.99, 899.99),
+(11, 2, 1, 299.99, 299.99),
+(11, 8, 1, 29.99, 29.99),
+(12, 5, 1, 129.99, 129.99),
+(12, 4, 1, 19.99, 19.99);
 
+-- Seed reviews
 INSERT INTO reviews (product_id, user_id, rating, title, comment, is_verified) VALUES
 (1, 1, 5, 'Excellent laptop!', 'Great performance and build quality. Highly recommended for professionals.', true),
 (2, 2, 4, 'Good headphones', 'Sound quality is great, but could be more comfortable for long use.', true),
 (3, 3, 5, 'Very helpful book', 'Clear explanations and practical examples. Perfect for beginners.', true),
 (4, 1, 3, 'Average quality', 'The fabric is okay but not as soft as expected.', false),
-(5, 4, 5, 'Perfect running shoes', 'Comfortable and durable. Great for daily running.', true);
+(5, 4, 5, 'Perfect running shoes', 'Comfortable and durable. Great for daily running.', true),
+(9, 6, 4, 'Helpful tracker', 'Solid activity tracking and battery life.', true),
+(10, 7, 5, 'Great hoodie', 'Warm, premium feel, and true to size.', true);
+
+-- Seed daily aggregate facts
+INSERT INTO daily_channel_metrics (
+    metric_date, store_id, channel_id, sessions, add_to_cart_sessions,
+    checkout_sessions, orders_count, revenue
+) VALUES
+('2024-01-15', 1, 3, 320, 74, 45, 18, 3150.00),
+('2024-01-15', 1, 4, 280, 61, 36, 14, 2210.00),
+('2024-01-16', 1, 1, 190, 42, 27, 11, 980.00),
+('2024-01-16', 2, 1, 150, 30, 20, 9, 720.00),
+('2024-01-17', 3, 2, 210, 39, 25, 10, 860.00),
+('2024-01-18', 1, 4, 295, 68, 40, 15, 2445.00),
+('2024-01-19', 2, 3, 260, 55, 33, 13, 2010.00),
+('2024-01-19', 3, 5, 130, 22, 15, 7, 560.00),
+('2024-01-20', 1, 2, 240, 48, 30, 12, 1180.00),
+('2024-01-20', 2, 4, 205, 36, 24, 8, 760.00),
+('2024-01-21', 1, 1, 215, 44, 28, 12, 1040.00),
+('2024-01-21', 3, 2, 225, 43, 27, 11, 990.00),
+('2024-01-22', 2, 3, 270, 59, 35, 14, 2140.00),
+('2024-01-22', 1, 4, 305, 72, 44, 16, 2580.00);
 
 -- Create indexes for better query performance
 CREATE INDEX idx_users_email ON users(email);
 CREATE INDEX idx_users_active ON users(is_active);
+CREATE INDEX idx_users_store ON users(preferred_store_id);
 CREATE INDEX idx_orders_user_id ON orders(user_id);
+CREATE INDEX idx_orders_store_id ON orders(store_id);
+CREATE INDEX idx_orders_channel_id ON orders(channel_id);
 CREATE INDEX idx_orders_status ON orders(status);
 CREATE INDEX idx_orders_date ON orders(order_date);
 CREATE INDEX idx_products_category ON products(category_id);
+CREATE INDEX idx_products_brand ON products(brand);
 CREATE INDEX idx_products_active ON products(is_active);
 CREATE INDEX idx_order_items_order ON order_items(order_id);
 CREATE INDEX idx_order_items_product ON order_items(product_id);
 CREATE INDEX idx_reviews_product ON reviews(product_id);
 CREATE INDEX idx_reviews_user ON reviews(user_id);
+CREATE INDEX idx_daily_channel_metrics_store_date ON daily_channel_metrics(store_id, metric_date);
+CREATE INDEX idx_daily_channel_metrics_channel_date ON daily_channel_metrics(channel_id, metric_date);
 
--- Create a view for order summaries
+-- Create views for richer reporting examples
 CREATE VIEW order_summaries AS
-SELECT 
-    o.id as order_id,
-    u.first_name || ' ' || u.last_name as customer_name,
-    u.email as customer_email,
+SELECT
+    o.id AS order_id,
+    s.code AS store_code,
+    s.domain AS store_domain,
+    s.region,
+    s.country,
+    mc.channel_name,
+    mc.source_category,
+    u.first_name || ' ' || u.last_name AS customer_name,
+    u.email AS customer_email,
     o.total_amount,
+    o.discount_amount,
     o.status,
     o.order_date,
-    COUNT(oi.id) as item_count
+    COUNT(oi.id) AS item_count
 FROM orders o
 JOIN users u ON o.user_id = u.id
+JOIN stores s ON o.store_id = s.id
+JOIN marketing_channels mc ON o.channel_id = mc.id
 LEFT JOIN order_items oi ON o.id = oi.order_id
-GROUP BY o.id, u.first_name, u.last_name, u.email, o.total_amount, o.status, o.order_date;
+GROUP BY
+    o.id, s.code, s.domain, s.region, s.country,
+    mc.channel_name, mc.source_category,
+    u.first_name, u.last_name, u.email,
+    o.total_amount, o.discount_amount, o.status, o.order_date;
 
--- Add some comments for AI understanding
-COMMENT ON TABLE users IS 'Customer information and user accounts';
-COMMENT ON TABLE products IS 'Product catalog with inventory and pricing';
-COMMENT ON TABLE orders IS 'Customer orders with status and payment info';
+CREATE VIEW store_channel_sales AS
+SELECT
+    DATE(o.order_date) AS metric_date,
+    s.code AS store_code,
+    s.region,
+    s.country,
+    mc.source_category,
+    COUNT(DISTINCT o.id) AS orders_count,
+    ROUND(SUM(o.total_amount)::numeric, 2) AS revenue
+FROM orders o
+JOIN stores s ON o.store_id = s.id
+JOIN marketing_channels mc ON o.channel_id = mc.id
+GROUP BY DATE(o.order_date), s.code, s.region, s.country, mc.source_category;
+
+-- Add comments for AI understanding
+COMMENT ON TABLE stores IS 'Storefront dimension with business region and country metadata';
+COMMENT ON TABLE marketing_channels IS 'Marketing channel dimension with business source categories and paid vs non-paid classification';
+COMMENT ON TABLE users IS 'Customer information, region, segment, and preferred storefront';
+COMMENT ON TABLE products IS 'Product catalog with brand, category, inventory and pricing';
+COMMENT ON TABLE orders IS 'Transactional orders tied to stores and marketing channels';
 COMMENT ON TABLE order_items IS 'Individual items within each order';
 COMMENT ON TABLE reviews IS 'Product reviews and ratings from customers';
 COMMENT ON TABLE categories IS 'Product categorization hierarchy';
+COMMENT ON TABLE daily_channel_metrics IS 'Daily aggregated ecommerce funnel and revenue metrics by store and marketing channel';

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,331 +1,384 @@
 # API Reference
 
-Complete reference for the nlp2sql Python API and CLI.
+This document covers the public Python API and the CLI surface. The recommended path is the DSL:
+
+- `await connect(...)`
+- `await nlp.ask(...)`
 
 ## Python API
 
 ### Entry Points
 
+```text
+nlp2sql.connect(url, provider=...)         # recommended DSL entry point
+  -> NLP2SQL.ask(question, ...)
+  -> NLP2SQL.validate(sql)
+  -> NLP2SQL.explain(sql)
+  -> NLP2SQL.suggest(partial)
+
+create_and_initialize_service(url, ...)    # lower-level service factory
+create_query_service(...)                   # manual wiring + manual initialize
+generate_sql_from_db(url, question, ...)   # one-shot helper
 ```
-nlp2sql.connect(url, provider=...)         # DSL: returns NLP2SQL client (recommended)
-  └─ nlp.ask(question)                     # returns QueryResult (.sql, .confidence, .is_valid)
-  └─ nlp.validate(sql)                     # validate a SQL string
-  └─ nlp.explain(sql)                      # explain a SQL query
-  └─ nlp.suggest(partial)                  # autocomplete suggestions
 
-create_and_initialize_service(url, ...)    # lower-level: returns QueryGenerationService
-  └─ service.generate_sql(question, ...)   # returns dict
 
-generate_sql_from_db(url, question, ...)   # one-shot: creates everything per call
-```
+| Function                          | Best for                              |
+| --------------------------------- | ------------------------------------- |
+| `connect()`                       | services, APIs, notebooks, workers    |
+| `create_and_initialize_service()` | advanced integration and custom ports |
+| `generate_sql_from_db()`          | quick scripts and experiments         |
 
-**When to use which:**
 
-| Function | Best for | Schema loading |
-|----------|----------|----------------|
-| `nlp2sql.connect()` | Most users, APIs, notebooks | Once at startup |
-| `create_and_initialize_service` | Custom wiring, legacy code | Once at startup |
-| `generate_sql_from_db` | One-off scripts | Every call |
-
-### `nlp2sql.connect()` (Recommended)
+## `connect(...)`
 
 ```python
 import nlp2sql
 from nlp2sql import ProviderConfig
 
 nlp = await nlp2sql.connect(
-    "postgresql://user:pass@localhost:5432/mydb",
+    "postgresql://testuser:testpass@localhost:5432/testdb",
     provider=ProviderConfig(provider="openai", api_key="sk-..."),
 )
-
-result = await nlp.ask("Show me all active users")
-print(result.sql)           # Generated SQL
-print(result.confidence)    # 0.0 - 1.0
-print(result.is_valid)      # bool
-print(result.explanation)   # Natural language explanation
 ```
 
-**Parameters:**
+### Common Parameters
 
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `database_url` | `str` | Yes | Database connection URL |
-| `provider` | `ProviderConfig` | No | AI provider configuration (falls back to env vars) |
-| `schema` | `str` | No | Database schema name (default: `"public"`) |
-| `database_type` | `DatabaseType` | No | Auto-detected from URL if not provided |
-| `schema_filters` | `dict` | No | Schema filtering options |
-| `examples` | `list[dict]` or `ExampleRepositoryPort` | No | Few-shot examples (see below) |
-| `embedding_provider` | `EmbeddingProviderPort` | No | Pre-built embedding provider |
-| `embedding_provider_type` | `str` | No | Auto-create embeddings: `"local"` or `"openai"` |
 
-**Returns:** `NLP2SQL` client with `.ask()`, `.validate()`, `.explain()`, `.suggest()` methods.
+| Parameter                 | Type                                        | Description                                                         |
+| ------------------------- | ------------------------------------------- | ------------------------------------------------------------------- |
+| `database_url`            | `str`                                       | Database connection URL                                             |
+| `provider`                | `ProviderConfig | None`                     | Provider config, otherwise resolved from environment                |
+| `schema`                  | `str | None`                                | Schema name, usually `public` for PostgreSQL                        |
+| `database_type`           | `DatabaseType | None`                       | Optional explicit override                                          |
+| `schema_filters`          | `dict | None`                               | Include or exclude schemas and tables                               |
+| `examples`                | `list[dict] | ExampleRepositoryPort | None` | Few-shot examples or custom repository                              |
+| `embedding_provider`      | `EmbeddingProviderPort | None`              | Custom embedding provider instance                                  |
+| `embedding_provider_type` | `str | None`                                | Auto-create embedding provider, typically `local` or `openai`       |
+| `hooks`                   | `ExecutionHooks | None`                     | Execution, classification, and repair hooks                         |
+| `semantic_hooks`          | `SemanticHooks | None`                      | Semantic resolver, validator, and optional default semantic context |
+| `semantic_context`        | `SemanticContext | dict | None`             | Default semantic context applied to future `ask()` calls            |
 
-### `ProviderConfig`
 
-Unified configuration for AI providers:
+### `hooks`
+
+`hooks` is where execution-related behavior lives. Typical uses:
+
+- plugging in a query execution port
+- classifying runtime failures
+- defining repair behavior
+
+This is what enables `validate=True` and `repair=True` to do more than prompt-only validation.
+
+### `semantic_hooks`
+
+`semantic_hooks` is the semantic counterpart:
+
+- `semantic_resolver`
+- `semantic_validator`
+- `semantic_context`
+
+Use it when your service wants shared business semantics for every call from that client instance.
+
+### `semantic_context`
+
+You can also pass semantic context directly into `connect()`. That context becomes the default for the client and may later be overridden per request in `ask(...)`.
+
+## `ProviderConfig`
 
 ```python
 from nlp2sql import ProviderConfig
 
 config = ProviderConfig(
-    provider="openai",          # "openai", "anthropic", "gemini"
-    api_key="sk-...",           # or use env vars
-    model="gpt-4o",            # None = provider default
-    temperature=0.1,            # None = 0.1
-    max_tokens=2000,            # None = 2000
+    provider="openai",
+    api_key="sk-...",
+    model="gpt-4o",
+    temperature=0.0,
+    max_tokens=4000,
 )
-
-# Check resolved model
-print(config.resolved_model)  # "gpt-4o" (or default if model=None)
 ```
 
-**Default models per provider:**
 
-| Provider | Default Model |
-|----------|--------------|
-| openai | gpt-4o-mini |
-| anthropic | claude-sonnet-4-20250514 |
-| gemini | gemini-2.0-flash |
+| Field         | Meaning                            |
+| ------------- | ---------------------------------- |
+| `provider`    | `openai`, `anthropic`, or `gemini` |
+| `api_key`     | provider credential                |
+| `model`       | optional explicit model            |
+| `temperature` | generation temperature             |
+| `max_tokens`  | response budget                    |
 
-### `QueryResult`
 
-Typed result from `nlp.ask()`:
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `sql` | `str` | Generated SQL query |
-| `confidence` | `float` | Confidence score (0.0 - 1.0) |
-| `is_valid` | `bool` | SQL validation result |
-| `explanation` | `str \| None` | Natural language explanation |
-| `provider` | `str` | Provider that generated the SQL |
-| `database_type` | `str` | Database type used |
-| `tokens_used` | `int` | Tokens consumed |
-| `generation_time_ms` | `float` | Generation time in milliseconds |
-| `examples_used` | `int` | Number of few-shot examples included |
-| `metadata` | `dict` | Additional metadata |
-
-### Few-Shot Examples
-
-Pass a plain list of dicts to `connect()` -- it handles embedding and FAISS indexing:
+## `NLP2SQL.ask(...)`
 
 ```python
-nlp = await nlp2sql.connect(
-    "redshift://user:pass@host:5439/db",
-    provider=ProviderConfig(provider="openai", api_key="sk-..."),
-    schema="dwh_data_share_llm",
-    examples=[
-        {
-            "question": "Total revenue last month?",
-            "sql": "SELECT SUM(revenue) FROM sales WHERE date >= DATE_TRUNC('month', CURRENT_DATE - INTERVAL '1 month')",
-            "database_type": "redshift",
-        },
-        {
-            "question": "Orders by country",
-            "sql": "SELECT country, COUNT(*) FROM orders GROUP BY country ORDER BY 2 DESC",
-            "database_type": "redshift",
-        },
-    ],
+result = await nlp.ask(
+    "Show revenue and order count by source category for the North America flagship store",
+    validate=True,
+    repair=True,
 )
 ```
 
-For advanced control, pass an `ExampleRepositoryPort` instance instead.
+### Common Parameters
 
-### Error Handling
+
+| Parameter          | Type                            | Description                                            |
+| ------------------ | ------------------------------- | ------------------------------------------------------ |
+| `question`         | `str`                           | Natural language request                               |
+| `validate`         | `bool`                          | Run validation behavior if execution is available      |
+| `repair`           | `bool`                          | Allow repair attempts on semantic or execution failure |
+| `execution_mode`   | `str | None`                    | Explicit mode override                                 |
+| `timeout_seconds`  | `int | float | None`            | Optional timeout for execution-aware flows             |
+| `semantic_context` | `SemanticContext | dict | None` | Per-request semantic override                          |
+
+
+### Execution Modes
+
+`ask()` supports three practical modes:
+
+
+| Mode                       | Meaning                                       |
+| -------------------------- | --------------------------------------------- |
+| `generate_only`            | Generate SQL and stop                         |
+| `generate_and_validate`    | Generate and validate execution when possible |
+| `generate_validate_repair` | Generate, validate, and attempt repair        |
+
+
+If you do not pass `execution_mode`, the library infers it from `validate` and `repair`.
+
+## `QueryResult`
+
+`ask()` returns a typed `QueryResult`.
+
+
+| Field                | Type                | Description                                    |
+| -------------------- | ------------------- | ---------------------------------------------- |
+| `sql`                | `str`               | Generated SQL                                  |
+| `confidence`         | `float`             | Confidence score                               |
+| `is_valid`           | `bool`              | Final validation state                         |
+| `explanation`        | `str | None`        | Optional natural-language explanation          |
+| `provider`           | `str`               | Provider that generated the SQL                |
+| `database_type`      | `str`               | Postgres or Redshift                           |
+| `tokens_used`        | `int`               | Tokens consumed                                |
+| `generation_time_ms` | `float`             | End-to-end generation time                     |
+| `examples_used`      | `int`               | Count of selected examples                     |
+| `metadata`           | `dict[str, object]` | Runtime metadata for debugging and integration |
+
+
+### `QueryResult.metadata`
+
+The metadata payload is intentionally rich. Common fields include:
+
+
+| Key                    | Description                                   |
+| ---------------------- | --------------------------------------------- |
+| `semantic_context`     | Resolved semantic context used for the call   |
+| `sql_intent_plan`      | Structured intent plan built before prompting |
+| `selected_examples`    | Few-shot examples selected for prompting      |
+| `repair_attempts`      | Repair loop details when repair is enabled    |
+| `execution_validation` | Execution-time validation outcome             |
+| `analysis`             | Query analysis hints                          |
+
+
+Exact contents may vary by runtime path and enabled hooks.
+
+## Few-Shot Examples
+
+Pass examples as plain dictionaries and the library will build or reuse the retrieval index automatically:
+
+```python
+examples = [
+    {
+        "question": "Show revenue by source category for the flagship store",
+        "sql": (
+            "SELECT d.metric_date, mc.source_category, SUM(d.revenue) AS revenue "
+            "FROM daily_channel_metrics d "
+            "JOIN stores s ON d.store_id = s.id "
+            "JOIN marketing_channels mc ON d.channel_id = mc.id "
+            "WHERE s.code = 'na_flagship' "
+            "GROUP BY d.metric_date, mc.source_category"
+        ),
+        "database_type": "postgres",
+    }
+]
+
+nlp = await nlp2sql.connect(
+    "postgresql://testuser:testpass@localhost:5432/testdb",
+    provider=ProviderConfig(provider="openai", api_key="sk-..."),
+    examples=examples,
+)
+```
+
+If you need more control, provide an `ExampleRepositoryPort` implementation instead.
+
+## Semantic Context
+
+Semantic context may be passed either through `connect()` or per call via `ask()`.
+
+```python
+from nlp2sql import (
+    DimensionDefinition,
+    DomainRule,
+    MetricDefinition,
+    SemanticContext,
+)
+
+semantic_context = SemanticContext(
+    domain="ecommerce_channel_performance",
+    canonical_tables=["daily_channel_metrics"],
+    required_filters=["s.code = 'na_flagship'"],
+    metric_definitions=[
+        MetricDefinition(name="revenue", description="Channel revenue by day."),
+        MetricDefinition(name="orders_count", description="Order count by day."),
+    ],
+    dimension_definitions=[
+        DimensionDefinition(name="source_category", description="Channel grouping."),
+    ],
+    rules=[
+        DomainRule(
+            name="keep_source_category",
+            description="Use source_category when the question asks for channel or source breakdown.",
+            required_dimensions=["source_category"],
+            preferred_tables=["daily_channel_metrics"],
+        )
+    ],
+)
+
+result = await nlp.ask(
+    "Show revenue by source category for the flagship store",
+    semantic_context=semantic_context,
+)
+```
+
+## Lower-Level Service API
+
+Use the service layer only when you need full control over dependency injection.
+
+```python
+from nlp2sql import DatabaseType, ProviderConfig, create_and_initialize_service
+
+service = await create_and_initialize_service(
+    database_url="postgresql://testuser:testpass@localhost:5432/testdb",
+    provider_config=ProviderConfig(provider="openai", api_key="sk-..."),
+    database_type=DatabaseType.POSTGRES,
+)
+
+result = await service.generate_sql(
+    "Count active users by region",
+    database_type=DatabaseType.POSTGRES,
+)
+
+print(result["sql"])
+print(result["validation"]["is_valid"])
+```
+
+## Error Handling
 
 ```python
 from nlp2sql.exceptions import (
-    SchemaException,
-    QueryGenerationException,
-    TokenLimitException,
     ProviderException,
+    QueryGenerationException,
+    SchemaException,
     SecurityException,
+    TokenLimitException,
 )
 
 try:
     result = await nlp.ask("Show revenue by month")
 except TokenLimitException:
-    print("Schema too large -- add schema_filters")
+    print("The schema context is too large. Add schema filters.")
 except SchemaException:
-    print("Database connection or schema error")
+    print("Database connection or schema discovery failed.")
 except QueryGenerationException:
-    print("AI provider failed to generate SQL")
+    print("The provider could not generate SQL.")
 except ProviderException:
-    print("AI provider API error (rate limit, auth, etc.)")
+    print("Provider auth, network, or rate-limit error.")
+except SecurityException:
+    print("Generated SQL failed safety checks.")
 ```
-
-### Advanced: Direct Service Access
-
-For full control over the lifecycle:
-
-```python
-from nlp2sql import create_and_initialize_service, ProviderConfig, DatabaseType
-
-service = await create_and_initialize_service(
-    database_url="postgresql://localhost/mydb",
-    provider_config=ProviderConfig(provider="openai", api_key="sk-..."),
-    database_type=DatabaseType.POSTGRES,
-)
-
-# Returns raw dict (not QueryResult)
-result = await service.generate_sql("Count total users", database_type=DatabaseType.POSTGRES)
-print(result["sql"])
-print(result["validation"]["is_valid"])
-```
-
----
 
 ## CLI Reference
 
-### Installation Verification
-
-```bash
-uv run nlp2sql --help
-uv run nlp2sql validate
-```
-
-### Core Commands
-
-#### `nlp2sql query`
+### `nlp2sql query`
 
 Generate SQL from natural language.
 
 ```bash
-# Basic query (auto-detects provider)
 nlp2sql query \
-  --database-url postgresql://user:pass@localhost:5432/db \
-  --question "Show me all active users"
-
-# Specify provider
-nlp2sql query \
-  --database-url postgresql://user:pass@localhost:5432/db \
-  --question "Count total orders" \
-  --provider anthropic
-
-# With explanation and schema filters
-nlp2sql query \
-  --database-url postgresql://user:pass@localhost:5432/db \
-  --question "Show sales by region" \
+  --database-url postgresql://testuser:testpass@localhost:5432/testdb \
   --provider openai \
-  --explain \
-  --schema-filters '{"include_schemas": ["sales"], "exclude_system_tables": true}'
+  --question "Show daily revenue by source category for the North America flagship store" \
+  --examples-file examples/ecommerce_examples.json \
+  --semantic-context-file examples/ecommerce_semantic_context.json \
+  --validate \
+  --repair \
+  --show-semantic-context \
+  --show-sql-intent-plan \
+  --show-selected-examples
 ```
 
-**Options:**
-| Option | Description |
-|--------|-------------|
-| `--database-url` | Database connection URL |
-| `--question` | Natural language question |
-| `--provider` | AI provider: `openai`, `anthropic`, `gemini` |
-| `--api-key` | API key (or use environment variable) |
-| `--explain` | Include detailed explanation |
-| `--temperature` | Model creativity (0.0-1.0) |
-| `--max-tokens` | Maximum response tokens |
-| `--schema-filters` | JSON string with schema filters |
+### Important Query Options
 
-#### `nlp2sql inspect`
 
-Inspect database schema.
+| Option                     | Meaning                                  |
+| -------------------------- | ---------------------------------------- |
+| `--database-url`           | Database connection URL                  |
+| `--schema`                 | Schema name                              |
+| `--provider`               | `openai`, `anthropic`, or `gemini`       |
+| `--api-key`                | Explicit provider key                    |
+| `--embedding-provider`     | Example and schema embedding provider    |
+| `--schema-filters`         | JSON schema filters                      |
+| `--examples-file`          | Load few-shot examples from JSON or YAML |
+| `--examples-json`          | Inline example payload                   |
+| `--semantic-context-file`  | Load semantic context from JSON or YAML  |
+| `--semantic-context-json`  | Inline semantic context payload          |
+| `--validate`               | Enable execution validation              |
+| `--repair`                 | Enable repair loop                       |
+| `--show-semantic-context`  | Print resolved semantic context          |
+| `--show-sql-intent-plan`   | Print generated SQL intent plan          |
+| `--show-selected-examples` | Print selected few-shot examples         |
+
+
+These flags are the CLI equivalents of the Python DSL features.
+
+### `nlp2sql benchmark`
+
+Benchmark one or more providers against the same workload.
 
 ```bash
-# Basic inspection
-nlp2sql inspect --database-url postgresql://user:pass@localhost:5432/db
+nlp2sql benchmark \
+  --database-url postgresql://testuser:testpass@localhost:5432/testdb \
+  --providers openai,anthropic \
+  --questions benchmark_questions.txt \
+  --examples-file examples/ecommerce_examples.json \
+  --semantic-context-file examples/ecommerce_semantic_context.json \
+  --iterations 2
+```
 
-# Filtered inspection
-nlp2sql inspect \
-  --database-url postgresql://user:pass@localhost:5432/db \
-  --exclude-system \
-  --min-rows 1000 \
-  --sort-by size \
-  --format json \
-  --output schema.json
+The benchmark command also accepts examples and semantic context so provider comparisons stay fair.
 
-# Specific tables
+### `nlp2sql inspect`
+
+Inspect the schema available to the library:
+
+```bash
 nlp2sql inspect \
-  --database-url postgresql://user:pass@localhost:5432/db \
-  --include-tables users,products,orders \
+  --database-url postgresql://testuser:testpass@localhost:5432/testdb \
+  --include-tables stores,marketing_channels,daily_channel_metrics \
   --format table
 ```
 
-**Options:**
-| Option | Description |
-|--------|-------------|
-| `--include-tables` | Comma-separated tables to include |
-| `--exclude-tables` | Comma-separated tables to exclude |
-| `--exclude-system` | Exclude system tables |
-| `--min-rows` | Minimum row count filter |
-| `--max-tables` | Limit number of tables shown |
-| `--sort-by` | Sort by: `name`, `rows`, `size`, `columns` |
-| `--format` | Output: `summary`, `json`, `table`, `csv` |
-| `--output` | Output file path |
+### `nlp2sql cache`
 
-#### `nlp2sql benchmark`
-
-Benchmark AI providers.
+Inspect or clear caches:
 
 ```bash
-# Benchmark all available providers
-nlp2sql benchmark \
-  --database-url postgresql://user:pass@localhost:5432/db
-
-# Custom benchmark
-nlp2sql benchmark \
-  --database-url postgresql://user:pass@localhost:5432/db \
-  --questions benchmark_questions.txt \
-  --providers openai,anthropic,gemini \
-  --iterations 3
-```
-
-**Options:**
-| Option | Description |
-|--------|-------------|
-| `--questions` | File with test questions (one per line) |
-| `--providers` | Comma-separated providers to test |
-| `--iterations` | Number of iterations per test |
-| `--schema-filters` | JSON string with schema filters |
-
-#### `nlp2sql providers`
-
-Manage AI providers.
-
-```bash
-# List providers and status
-nlp2sql providers list
-
-# Test provider connections
-nlp2sql providers test
-nlp2sql providers test --provider openai
-```
-
-#### `nlp2sql cache`
-
-Manage cache.
-
-```bash
-# Show cache info
 nlp2sql cache info
-
-# Clear cache
-nlp2sql cache clear --all
 nlp2sql cache clear --embeddings
 nlp2sql cache clear --queries
 ```
 
-#### `nlp2sql setup` and `nlp2sql validate`
+Clearing embeddings is required when switching embedding models or providers for an existing on-disk index.
 
-Setup and validation.
-
-```bash
-# Interactive setup
-nlp2sql setup
-
-# Validate configuration
-nlp2sql validate
-nlp2sql validate -v  # Verbose
-```
-
----
-
-## Integration Examples
+## Integration Example
 
 ### FastAPI
 
@@ -334,52 +387,39 @@ import os
 from contextlib import asynccontextmanager
 
 import nlp2sql
-from fastapi import FastAPI, HTTPException
-from nlp2sql import ProviderConfig
-from pydantic import BaseModel
+from fastapi import FastAPI
+from nlp2sql import ProviderConfig, SemanticContext
 
-nlp_client = None
+
+client = None
+
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    global nlp_client
-    nlp_client = await nlp2sql.connect(
+    global client
+    client = await nlp2sql.connect(
         os.getenv("DATABASE_URL"),
         provider=ProviderConfig(provider="openai", api_key=os.getenv("OPENAI_API_KEY")),
+        semantic_context=SemanticContext(
+            domain="ecommerce_channel_performance",
+            canonical_tables=["daily_channel_metrics"],
+        ),
     )
     yield
 
+
 app = FastAPI(lifespan=lifespan)
 
-class QueryRequest(BaseModel):
-    question: str
 
 @app.post("/query")
-async def generate_query(request: QueryRequest):
-    result = await nlp_client.ask(request.question)
-    return {"sql": result.sql, "confidence": result.confidence, "valid": result.is_valid}
+async def query(payload: dict[str, str]):
+    result = await client.ask(payload["question"], validate=True, repair=True)
+    return {"sql": result.sql, "metadata": result.metadata}
 ```
 
-### Jupyter Notebook
+## Related Docs
 
-```python
-import nlp2sql
-from nlp2sql import ProviderConfig
+- [README](../README.md)
+- [Architecture](ARCHITECTURE.md)
+- [Configuration](CONFIGURATION.md)
 
-nlp = await nlp2sql.connect(
-    "postgresql://localhost/analytics",
-    provider=ProviderConfig(provider="openai", api_key="sk-..."),
-)
-
-result = await nlp.ask("Show user engagement by month")
-print(result.sql)
-
-# Execute with pandas
-import pandas as pd
-df = pd.read_sql(result.sql, "postgresql://localhost/analytics")
-df.head()
-```
-
----
-
-For configuration options including environment variables and schema filters, see [CONFIGURATION.md](CONFIGURATION.md).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,319 +1,366 @@
 # Architecture
 
-nlp2sql follows Clean Architecture (Hexagonal/Ports & Adapters) principles, enabling multi-provider support and maintainability at enterprise scale.
+`nlp2sql` follows a hexagonal architecture: the public DSL and CLI sit at the edge, the core domain stays pure, and adapters implement provider- or infrastructure-specific behavior.
 
-## Component Diagram
+The important shift in the current architecture is that SQL generation is no longer treated as just:
+
+`question -> schema -> SQL`
+
+It is now modeled as:
+
+`question -> semantic resolution -> schema/examples retrieval -> SQL intent plan -> prompt assembly -> SQL -> semantic/execution validation`
+
+## Runtime Overview
+
+```mermaid
+flowchart TD
+    userCode[User code or CLI] --> dsl[connect() / ask()]
+    dsl --> qgs[QueryGenerationService]
+    qgs --> analysis[Query analysis]
+    analysis --> semantic[SemanticResolutionService]
+    semantic --> schema[Schema retrieval]
+    semantic --> examples[Example selection]
+    schema --> intent[SqlIntentPlanningService]
+    examples --> intent
+    intent --> prompt[PromptAssemblyService]
+    prompt --> provider[AIProviderPort adapter]
+    provider --> semval[SemanticValidationService]
+    semval --> exec[Optional execution validation and repair]
+    exec --> result[QueryResult metadata]
+```
+
+## Public Surfaces
+
+The recommended entry point is the DSL:
+
+- `await nlp2sql.connect(...)`
+- `await nlp.ask(...)`
+
+Other entry points still exist for advanced wiring:
+
+- `create_and_initialize_service(...)`
+- `create_query_service(...)`
+- `generate_sql_from_db(...)`
+
+The CLI maps onto the same runtime concepts through `nlp2sql query`, `inspect`, `benchmark`, and cache commands.
+
+## Layers
+
+### Core Domain
+
+The core layer contains the stable business-agnostic abstractions:
+
+- `ProviderConfig`
+- `QueryResult`
+- `SemanticContext`
+- `SqlIntentPlan`
+- `SemanticValidationResult`
+- SQL safety and keyword utilities
+
+These objects are designed so a service can pass semantic business meaning without hardcoding any specific private warehouse.
+
+### Ports
+
+Ports define the boundaries between orchestration and infrastructure:
+
+| Port | Purpose |
+|------|---------|
+| `AIProviderPort` | Generate and validate SQL through a model provider |
+| `SchemaRepositoryPort` | Read table and column metadata from PostgreSQL or Redshift |
+| `EmbeddingProviderPort` | Produce embeddings for schema and example retrieval |
+| `ExampleRepositoryPort` | Retrieve few-shot examples |
+| `SemanticResolverPort` | Resolve business context for a question |
+| `SemanticValidatorPort` | Validate generated SQL against business rules |
+| `QueryValidatorPort` | Detect column-level query issues |
+| `QuerySafetyPort` | Enforce readonly and safety rules |
+| `CachePort` | External cache for reusable results |
+
+### Adapters
+
+Adapters implement those ports:
+
+| Area | Adapters |
+|------|----------|
+| AI providers | OpenAI, Anthropic, Gemini |
+| Databases | PostgreSQL, Redshift |
+| Embeddings | local sentence-transformers, OpenAI embeddings |
+| Examples | `ExampleStore` and any custom repository implementation |
+| Semantic resolution | no-op, dictionary-backed, file-backed |
+| Semantic validation | no-op and custom validator implementations |
+| Query validation | regex-based validator today, swappable later |
+
+### Application Services
+
+The orchestration layer is centered on `QueryGenerationService`, which now composes several focused services:
+
+| Service | Responsibility |
+|---------|----------------|
+| `QueryGenerationService` | End-to-end orchestration |
+| `SemanticResolutionService` | Resolve and merge semantic context |
+| `SchemaManager` | Retrieve and compress schema context |
+| `ExampleSelectionService` | Find and rerank few-shot examples |
+| `SqlIntentPlanningService` | Build a structured plan before prompting |
+| `PromptAssemblyService` | Assemble the final `QueryContext` |
+| `SemanticValidationService` | Detect semantically wrong but syntactically valid SQL |
+
+## End-to-End Query Flow
+
+```mermaid
+sequenceDiagram
+    participant U as User or CLI
+    participant D as DSL Client
+    participant Q as QueryGenerationService
+    participant SR as SemanticResolutionService
+    participant SM as SchemaManager
+    participant ES as ExampleSelectionService
+    participant IP as SqlIntentPlanningService
+    participant PA as PromptAssemblyService
+    participant AI as AI Adapter
+    participant SV as SemanticValidationService
+    participant EV as Execution/Repair
+
+    U->>D: ask(question, semantic_context=?, validate=?, repair=?)
+    D->>Q: generate_sql(...)
+    Q->>Q: query analysis
+    Q->>SR: resolve semantic context
+    SR-->>Q: SemanticContext
+    Q->>SM: retrieve schema context
+    Q->>ES: select examples
+    SM-->>Q: relevant schema
+    ES-->>Q: selected examples
+    Q->>IP: build SqlIntentPlan
+    IP-->>Q: structured plan
+    Q->>PA: assemble prompt context
+    PA-->>Q: QueryContext
+    Q->>AI: generate_query(QueryContext)
+    AI-->>Q: SQL response
+    Q->>SV: validate semantic correctness
+    SV-->>Q: semantic issues or pass
+    Q->>EV: optional execution validation and repair
+    EV-->>Q: final SQL and validation state
+    Q-->>D: QueryResult
+    D-->>U: SQL + metadata
+```
+
+## Detailed Pipeline
+
+### 1. Query Analysis
+
+The pipeline begins by extracting lightweight intent hints from the question, such as candidate metrics, dimensions, filters, or time expressions. This step gives later services a normalized starting point even when no examples or semantic context are provided.
+
+### 2. Semantic Resolution
+
+Semantic resolution is optional but first-class.
+
+Possible inputs:
+
+- no semantic context at all
+- a per-client `semantic_context`
+- a per-request `semantic_context`
+- a `semantic_resolver` hook
+- a file- or dict-backed semantic resolver used by the CLI
+
+The output is a `SemanticContext` that may contain:
+
+- canonical tables
+- supporting tables
+- required filters
+- entity mappings
+- metric definitions
+- dimension definitions
+- rules
+- canonical query patterns
+
+This step is what lets business meaning steer the rest of the pipeline without baking private conventions into the library.
+
+### 3. Schema Retrieval
+
+`SchemaManager` retrieves relevant schema using:
+
+- schema filters
+- disk-backed schema metadata
+- dense retrieval with embeddings
+- sparse retrieval with TF-IDF
+- score reuse during context compression
+
+This is the main defense against very large schemas.
+
+### 4. Example Selection
+
+Few-shot examples are optional. If present, they are treated as a separate retrieval artifact, not as a replacement for schema retrieval.
+
+Selection can be influenced by:
+
+- question similarity
+- semantic context
+- canonical table overlap
+- filter overlap
+
+This keeps examples aligned with the resolved business intent instead of only the raw question text.
+
+### 5. SQL Intent Planning
+
+Before building the final prompt, the system creates a `SqlIntentPlan`.
+
+The plan captures:
+
+- domain
+- fact table
+- supporting tables
+- dimensions
+- metrics
+- filters
+- time range hints
+- grouping hints
+- ordering hints
+
+This is the bridge between semantic meaning and SQL generation. It narrows the solution space for the model and makes the resulting metadata easier to inspect.
+
+### 6. Prompt Assembly
+
+`PromptAssemblyService` creates a `QueryContext` for the AI provider. That context includes:
+
+- question
+- compressed schema context
+- selected examples
+- semantic context metadata
+- SQL intent plan metadata
+
+The provider adapters then render this information into provider-specific prompts.
+
+### 7. Generation
+
+The AI provider generates SQL using the assembled context. Providers are interchangeable because they all sit behind `AIProviderPort`.
+
+### 8. Semantic Validation
+
+After generation, the system can validate the SQL against business rules. This catches failures that would otherwise slip through syntax-only validation, for example:
+
+- missing required filters
+- missing required dimensions
+- use of disallowed tables
+- failure to honor a canonical table choice
+
+### 9. Optional Execution and Repair
+
+If execution is enabled:
+
+- the query may be executed in readonly mode
+- execution failures can trigger repair
+- semantic failures can also trigger repair
+
+This is how the library supports `generate_only`, `generate_and_validate`, and `generate_validate_repair`.
+
+## Component Map
 
 ```mermaid
 graph TB
-    subgraph "Public API"
-        DSL["nlp2sql.connect() → NLP2SQL.ask()"]
-        API["create_and_initialize_service()<br>generate_sql_from_db()"]
+    subgraph Public
+        DSL[NLP2SQL DSL]
+        CLI[CLI]
     end
 
-    subgraph "Core (Pure Python)"
-        PC[ProviderConfig]
-        QR[QueryResult]
-        SS[sql_safety / sql_keywords]
-    end
-
-    subgraph "Service Layer"
+    subgraph Application
         QGS[QueryGenerationService]
+        SRSem[SemanticResolutionService]
+        SMSchema[SchemaManager]
+        EX[ExampleSelectionService]
+        IP[SqlIntentPlanningService]
+        PA[PromptAssemblyService]
+        SV[SemanticValidationService]
     end
 
-    subgraph "Schema Management"
-        SM[SchemaManager]
-        SA[SchemaAnalyzer<br>- relevance scoring<br>- compression]
-        SEM[SchemaEmbeddingManager<br>- FAISS index<br>- TF-IDF search]
-    end
-
-    subgraph "Ports (Interfaces)"
+    subgraph Ports
         AIP[AIProviderPort]
         SRP[SchemaRepositoryPort]
-        EP[EmbeddingProviderPort]
         ERP[ExampleRepositoryPort]
+        EMB[EmbeddingProviderPort]
+        SEMR[SemanticResolverPort]
+        SEMV[SemanticValidatorPort]
         QVP[QueryValidatorPort]
         QSP[QuerySafetyPort]
     end
 
-    subgraph "AI Adapters"
-        OA[OpenAI Adapter]
-        AA[Anthropic Adapter]
-        GA[Gemini Adapter]
-    end
-
-    subgraph "Database Adapters"
-        PG[PostgreSQL Repository]
-        RS[Redshift Repository]
-    end
-
-    subgraph "Embedding Adapters"
-        LE[Local Embeddings<br>sentence-transformers]
-        OE[OpenAI Embeddings]
-    end
-
-    subgraph "Other Adapters"
-        ES[ExampleStore<br>FAISS-backed]
-        RQV[RegexQueryValidator]
+    subgraph Adapters
+        OA[OpenAI]
+        AA[Anthropic]
+        GA[Gemini]
+        PG[PostgreSQL]
+        RS[Redshift]
+        ES[ExampleStore]
+        DSR[Dict/File Semantic Resolver]
+        NSV[NoOp or Custom Semantic Validator]
     end
 
     DSL --> QGS
-    API --> QGS
-    DSL -.-> PC
-    DSL -.-> QR
-    QGS --> SM
+    CLI --> QGS
+    QGS --> SRSem
+    QGS --> SMSchema
+    QGS --> EX
+    QGS --> IP
+    QGS --> PA
+    QGS --> SV
     QGS --> AIP
-    QGS --> ERP
     QGS --> QVP
-    SM --> SA
-    SM --> SEM
-    SM --> SRP
-    SEM --> EP
+    QGS --> QSP
+    SRSem --> SEMR
+    SV --> SEMV
+    SMSchema --> SRP
+    SMSchema --> EMB
+    EX --> ERP
+    EX --> EMB
     AIP --> OA
     AIP --> AA
     AIP --> GA
     SRP --> PG
     SRP --> RS
-    EP --> LE
-    EP --> OE
     ERP --> ES
-    QVP --> RQV
-    PG -.-> SS
-    RS -.-> SS
+    SEMR --> DSR
+    SEMV --> NSV
 ```
 
-## Component Descriptions
+## Caching and Persistence
 
-### Public API
+The architecture uses several cache layers:
 
-Entry points for the library:
+| Layer | Purpose | Typical Storage |
+|-------|---------|-----------------|
+| schema embedding cache | reuse schema retrieval indexes | disk |
+| example embedding cache | reuse example search indexes | disk |
+| repository schema cache | avoid repeated catalog scans | disk or memory |
+| query result cache | reuse final query results | external cache port |
+| in-process relevance caches | avoid repeated scoring inside a run | memory |
 
-| Function | Purpose |
-|----------|---------|
-| `nlp2sql.connect()` | **Recommended.** DSL entry point: returns `NLP2SQL` client with `.ask()`, `.validate()`, `.explain()` |
-| `create_and_initialize_service` | Lower-level: returns `QueryGenerationService` for advanced wiring |
-| `create_query_service` | Full manual control; caller must call `initialize()` manually |
-| `generate_sql_from_db` | One-shot convenience: creates everything per call |
-
-### Service Layer
-
-**QueryGenerationService** (`services/query_service.py`) orchestrates the full pipeline:
-
-1. Check query cache
-2. Get optimal schema context via `SchemaManager`
-3. Find relevant examples via `ExampleRepositoryPort` (if configured)
-4. Build `QueryContext` and call `AIProvider.generate_query()`
-5. Validate columns via `QueryValidatorPort` (retry once if errors found)
-6. Optionally optimize via `QueryOptimizerPort`
-7. Validate SQL via `AIProvider.validate_query()`
-8. Cache valid results
-
-### Schema Management
-
-| Component | File | Responsibility |
-|-----------|------|----------------|
-| **SchemaManager** | `schema/manager.py` | Coordinates filtering, relevance search, and context building |
-| **SchemaAnalyzer** | `schema/analyzer.py` | Scores table/column relevance (text + semantic), compresses schema within token limits |
-| **SchemaEmbeddingManager** | `schema/embedding_manager.py` | Maintains FAISS vector index + TF-IDF sparse index for hybrid search |
-
-### Ports (Interfaces)
-
-Abstract contracts in `ports/` that define layer boundaries:
-
-| Port | File | Methods |
-|------|------|---------|
-| **AIProviderPort** | `ports/ai_provider.py` | `generate_query()`, `validate_query()` |
-| **SchemaRepositoryPort** | `ports/schema_repository.py` | `get_tables()`, `get_table_info()`, `get_related_tables()` |
-| **EmbeddingProviderPort** | `ports/embedding_provider.py` | `encode()`, `get_embedding_dimension()` |
-| **ExampleRepositoryPort** | `ports/example_repository.py` | `add_examples()`, `search_similar()`, `clear()`, `get_stats()` |
-| **QueryValidatorPort** | `ports/query_validator.py` | `validate_columns()` |
-| **QuerySafetyPort** | `ports/query_safety.py` | `validate()`, `apply_row_limit()` |
-| **SchemaStrategyPort** | `ports/schema_strategy.py` | `build_context()`, `score_relevance()`, `chunk_schema()` |
-| **CachePort** | `ports/cache.py` | `get()`, `set()`, `clear()` |
-| **QueryOptimizerPort** | `ports/query_optimizer.py` | `optimize()` |
-
-### Adapters
-
-Concrete implementations of ports:
-
-| Layer | Adapters | Files |
-|-------|----------|-------|
-| AI Providers | OpenAI GPT, Anthropic Claude, Google Gemini | `adapters/openai_adapter.py`, `anthropic_adapter.py`, `gemini_adapter.py` |
-| Databases | PostgreSQL, Amazon Redshift | `adapters/postgres_repository.py`, `redshift_adapter.py` |
-| Embeddings | Local (sentence-transformers), OpenAI | `adapters/local_embedding_adapter.py`, `openai_embedding_adapter.py` |
-| Examples | FAISS-backed ExampleStore | `schema/example_store.py` (implements `ExampleRepositoryPort`) |
-| Validation | Regex-based column validator | `adapters/regex_query_validator.py` (implements `QueryValidatorPort`) |
-
-## Detailed Query Flow
-
-```mermaid
-sequenceDiagram
-    participant User
-    participant QGS as QueryGenerationService
-    participant SM as SchemaManager
-    participant SEM as SchemaEmbeddingManager
-    participant SA as SchemaAnalyzer
-    participant Repo as SchemaRepository
-    participant AI as AIProvider
-
-    User->>QGS: generate_sql(question)
-    QGS->>QGS: Check query cache
-    QGS->>SM: get_optimal_schema_context(question)
-
-    SM->>SM: _find_relevant_tables(question)
-    SM->>SEM: search_similar_with_embedding(query)
-    SEM->>SEM: FAISS dense + TF-IDF sparse (50/50 hybrid)
-    SEM-->>SM: (results, query_embedding)
-
-    SM->>SEM: get_table_embeddings(table_names)
-    SEM->>SEM: Reconstruct from FAISS index (zero API calls)
-    SEM-->>SM: precomputed_element_embeddings
-
-    SM->>SA: score_relevance_batch(precomputed embeddings)
-    SA->>SA: Text scoring + semantic scoring (zero API calls)
-    SA-->>SM: scored tables
-
-    SM->>Repo: get_table_info(per table)
-    Repo-->>SM: TableInfo with columns, keys, indexes
-
-    Note over SM: Attaches relevance_score to each table dict
-
-    SM->>SA: build_context(tables with relevance_score)
-    SA->>SA: Reuses existing scores (zero API calls)
-    SA-->>SM: schema context string
-
-    SM-->>QGS: schema_context
-
-    QGS->>AI: generate_query(QueryContext)
-    AI-->>QGS: SQL + confidence + explanation
-    QGS->>AI: validate_query(sql, schema_context)
-    AI-->>QGS: validation result
-    QGS-->>User: {sql, confidence, explanation, validation}
-```
-
-### Step-by-step with file references
-
-1. **`generate_sql()`** (`services/query_service.py`) -- checks query cache, then calls `SchemaManager.get_optimal_schema_context()`
-2. **`get_optimal_schema_context()`** (`schema/manager.py`) -- checks schema cache, then calls `_find_relevant_tables()`
-3. **`_find_relevant_tables()`** (`schema/manager.py`) -- two strategies:
-   - **Strategy 1**: `SchemaEmbeddingManager.search_similar_with_embedding()` -- FAISS + TF-IDF hybrid search returns candidate tables + the query embedding
-   - **Strategy 2**: `SchemaAnalyzer.score_relevance_batch()` -- batch scores token-matched tables using precomputed query + element embeddings (reconstructed from FAISS via `get_table_embeddings()`)
-4. **`get_table_info()`** (`ports/schema_repository.py`) -- fetches full table metadata; manager attaches `relevance_score` to each table dict
-5. **`build_context()`** (`schema/analyzer.py`) -- builds schema context string within token limits; reuses pre-attached `relevance_score` (no re-scoring, zero additional embedding calls)
-6. **`generate_query()`** (`ports/ai_provider.py`) -- AI provider generates SQL from question + schema context
-7. **`validate_query()`** (`ports/ai_provider.py`) -- validates SQL syntax and safety
-
-## Schema Relevance Pipeline
-
-The pipeline in `_find_relevant_tables()` (`schema/manager.py`) uses two complementary strategies to find the most relevant tables for a query:
-
-### Strategy 1: Hybrid FAISS + TF-IDF Search
-
-`SchemaEmbeddingManager._search_similar_core()` (`schema/embedding_manager.py`) combines:
-
-- **Dense search (FAISS)**: Semantic similarity via vector embeddings (`IndexFlatIP` inner product). Captures meaning (e.g., "revenue" matches "sales_amount").
-- **Sparse search (TF-IDF)**: Exact keyword matching via `TfidfVectorizer` with unigram+bigram features. Captures exact names (e.g., "organizations" matches `organization` table).
-- **Hybrid score**: `0.5 * dense_score + 0.5 * sparse_score`. Equal weighting ensures both semantic meaning and exact keyword matches contribute.
-
-This returns candidate tables + the query embedding (for reuse downstream).
-
-### Strategy 2: Batch Scoring with Precomputed Embeddings
-
-`SchemaAnalyzer.score_relevance_batch()` (`schema/analyzer.py`) refines candidates:
-
-1. **Text-based scoring** (fast, no API calls): exact name match, normalized singular/plural matching, token overlap, column-name matching
-2. **Semantic scoring** (only for elements with text score < 0.8): uses precomputed embeddings passed from the manager, avoiding new API calls
-3. The manager passes both the `query_embedding` from Strategy 1 and `element_embeddings` reconstructed from the FAISS index via `get_table_embeddings()`
-
-### Score Reuse in build_context
-
-`SchemaManager.get_optimal_schema_context()` attaches the final `relevance_score` to each table dict before calling `SchemaAnalyzer.build_context()`. The analyzer checks for this key and skips re-scoring when present. This eliminates ~10-15 embedding API calls per query that would otherwise happen in the per-table `score_relevance()` path.
-
-**Net result**: ~1 embedding API call per query (for the initial FAISS search), down from ~15-18 without these optimizations.
-
-## Caching Layers
-
-The system has multiple caching layers:
-
-| Layer | Scope | Storage | TTL |
-|-------|-------|---------|-----|
-| **Query result cache** | Full SQL response | `CachePort` (external) | Indefinite (valid results) |
-| **Schema context cache** | Built schema string | `CachePort` (external) | Per query+db+tokens key |
-| **Table relevance cache** | Relevant tables list | In-memory dict | Per `SchemaManager` instance |
-| **All-tables cache** | Filtered table list | In-memory dict (`_schema_cache`) | Until `refresh_schema()` |
-| **FAISS + TF-IDF index** | Schema embeddings | Disk (pickle + FAISS) | Until `NLP2SQL_SCHEMA_CACHE_TTL_HOURS` expires |
-| **Query embedding cache** | Per-query embeddings | In-memory dict | Cleared per `_find_relevant_tables()` call |
-| **Repository disk cache** | Schema metadata (Redshift) | Pickle file | `NLP2SQL_SCHEMA_CACHE_TTL_HOURS` |
+The key architectural rule is that caches accelerate the pipeline but do not redefine it. Semantic context, example retrieval, and SQL planning remain explicit steps whether caches are warm or cold.
 
 ## Design Decisions
 
-| Decision | Rationale |
-|----------|-----------|
-| **Ports & Adapters** | Swap AI/DB/embedding providers without touching core logic. Adding a new provider means implementing one port interface. |
-| **FAISS + TF-IDF hybrid (50/50)** | Semantic embeddings alone miss exact keyword matches (e.g., "count organizations" should find `organization` table). TF-IDF catches these. Equal weighting balances both signals. |
-| **Disk-cached FAISS index** | Avoids re-embedding 600+ schema elements on every run. Isolated per database+schema via MD5 hash of `{database_url}:{schema_name}`. |
-| **Precomputed embeddings in batch scoring** | `_find_relevant_tables` reuses the query embedding from FAISS search and reconstructs table embeddings from the index. Result: ~1 embedding API call per query instead of ~15. |
-| **relevance_score passthrough to build_context** | Manager already scored tables during `_find_relevant_tables`; analyzer reuses those scores in `build_context` instead of re-computing them (zero redundant API calls). |
-| **Repository disk cache (Redshift)** | Redshift's `SVV_TABLES`/`SVV_COLUMNS` queries are expensive. Bulk query + pickle cache avoids repeated system catalog scans. |
-| **Graceful embedding degradation** | System works without embeddings (text-based matching only). If `sentence-transformers` is not installed, logs a warning and continues. |
-| **Schema filters applied before indexing** | Filters reduce the number of elements indexed in FAISS, making search faster and more focused. |
-| **DSL `connect()` + `ask()`** | Pythonic API inspired by httpx/redis-py. Auto-detects database type, auto-creates embeddings, accepts plain dicts for examples. Wraps `QueryGenerationService` without replacing it. |
-| **ProviderConfig** | Single object for AI provider settings (provider, api_key, model, temperature, max_tokens). Eliminates scattered params across factory functions. |
-| **QueryResult** | Typed dataclass instead of raw dict. `.sql`, `.confidence`, `.is_valid` instead of `result["sql"]`, `result["validation"]["is_valid"]`. |
-| **SQL safety in core** | `is_safe_query()` and `DANGEROUS_SQL_PATTERNS` moved from adapters to `core/sql_safety.py`. Eliminates duplication between PostgreSQL and Redshift adapters. |
-| **QueryValidatorPort** | Column validation logic (90 lines of regex) extracted from service to `adapters/regex_query_validator.py`. Enables future `sqlglot`-based implementation. |
-| **ExampleRepositoryPort** | Few-shot examples behind a port interface. `ExampleStore` (FAISS) is one implementation; users can provide DB-backed or API-backed stores. |
+| Decision | Why it matters |
+|----------|----------------|
+| DSL-first public API | Most users want `connect()` and `ask()`, not low-level service construction |
+| Semantic context as a first-class entity | Business meaning can be injected without forking the library |
+| Intent planning before prompting | Keeps SQL generation structured and inspectable |
+| Examples behind a port | Examples can come from files, memory, databases, or external systems |
+| Semantic validation after generation | Catches wrong SQL that still parses and executes |
+| Ports and adapters | Lets teams swap providers and infrastructure without rewriting orchestration |
+| Public examples tied to local e-commerce schema | Keeps docs safe, portable, and reproducible |
 
-## Directory Structure
+## Public Example Domain
 
-```
-src/nlp2sql/
-├── client.py       # DSL: connect() + NLP2SQL class (recommended entry point)
-├── __init__.py     # Public API: exports, factory functions
-├── core/           # Pure Python, no external dependencies
-│   ├── entities.py         # Query, SQLQuery, DatabaseType
-│   ├── provider_config.py  # ProviderConfig (AI provider settings)
-│   ├── result.py           # QueryResult (typed result from ask())
-│   ├── database_prompts.py # SQL dialect hints for AI providers
-│   ├── sql_safety.py       # is_safe_query(), apply_row_limit(), DANGEROUS_SQL_PATTERNS
-│   └── sql_keywords.py     # SQL_KEYWORDS frozenset (shared by validators)
-├── ports/          # Interfaces/abstractions
-│   ├── ai_provider.py       # AIProviderPort, QueryContext, QueryResponse
-│   ├── schema_repository.py # SchemaRepositoryPort, TableInfo
-│   ├── embedding_provider.py # EmbeddingProviderPort
-│   ├── example_repository.py # ExampleRepositoryPort (few-shot examples)
-│   ├── query_validator.py   # QueryValidatorPort (column validation)
-│   ├── query_safety.py      # QuerySafetyPort (SQL safety checks)
-│   ├── schema_strategy.py   # SchemaStrategyPort, SchemaContext, SchemaChunk
-│   ├── cache.py             # CachePort
-│   └── query_optimizer.py   # QueryOptimizerPort
-├── adapters/       # External implementations
-│   ├── openai_adapter.py           # OpenAI GPT
-│   ├── anthropic_adapter.py        # Anthropic Claude
-│   ├── gemini_adapter.py           # Google Gemini
-│   ├── postgres_repository.py      # PostgreSQL
-│   ├── redshift_adapter.py         # Amazon Redshift (with disk cache)
-│   ├── local_embedding_adapter.py  # sentence-transformers
-│   ├── openai_embedding_adapter.py # OpenAI embeddings
-│   └── regex_query_validator.py    # Regex-based column validation
-├── services/       # Application services
-│   └── query_service.py    # QueryGenerationService (orchestrator)
-├── schema/         # Schema management
-│   ├── manager.py           # SchemaManager (coordinates strategies)
-│   ├── analyzer.py          # SchemaAnalyzer (scoring, compression)
-│   ├── embedding_manager.py # SchemaEmbeddingManager (FAISS + TF-IDF)
-│   └── example_store.py     # ExampleStore (implements ExampleRepositoryPort)
-├── config/         # Configuration
-│   └── settings.py          # Pydantic Settings (centralized defaults)
-├── utils/          # Shared utilities
-│   └── storage.py           # get_data_directory() (disk persistence)
-├── exceptions/     # Custom exception hierarchy
-└── factories.py    # RepositoryFactory
-```
+When the docs or tests refer to business concepts, they refer to the repository's local e-commerce schema, such as:
 
-## Related Documentation
+- `stores`
+- `marketing_channels`
+- `daily_channel_metrics`
+- `orders`
+- `order_items`
 
-- [API Reference](API.md) - Python API and CLI
-- [Configuration](CONFIGURATION.md) - Environment variables and design rationale
-- [Enterprise Guide](ENTERPRISE.md) - Large-scale deployment
-- [Redshift Support](Redshift.md) - Amazon Redshift setup
+This keeps the public architecture documentation grounded in a real domain without relying on private warehouse names.
+
+## Related Docs
+
+- [README](../README.md)
+- [API Reference](API.md)
+- [Configuration](CONFIGURATION.md)
+- [Enterprise Guide](ENTERPRISE.md)
+- [Redshift Support](Redshift.md)

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1,21 +1,29 @@
 # Configuration Reference
 
-This document is the single source of truth for all nlp2sql configuration options.
+This document explains how to configure `nlp2sql` for the DSL, CLI, tests, and production services.
+
+## Core Concepts
+
+Configuration falls into four buckets:
+
+- provider credentials
+- database and schema scope
+- retrieval and cache behavior
+- runtime guidance for semantic context, examples, and execution modes
 
 ## Environment Variables
 
-### AI Provider API Keys
+### Provider Credentials
 
-At least one AI provider API key is required.
+At least one provider key is required.
 
-| Variable | Required | Description |
-|----------|----------|-------------|
-| `OPENAI_API_KEY` | One of three | OpenAI API key for GPT-4 models |
-| `ANTHROPIC_API_KEY` | One of three | Anthropic API key for Claude models |
-| `GOOGLE_API_KEY` | One of three | Google API key for Gemini models |
+| Variable | Description |
+|----------|-------------|
+| `OPENAI_API_KEY` | OpenAI provider key |
+| `ANTHROPIC_API_KEY` | Anthropic provider key |
+| `GOOGLE_API_KEY` | Gemini provider key |
 
 ```bash
-# Set at least one provider key
 export OPENAI_API_KEY="sk-..."
 export ANTHROPIC_API_KEY="sk-ant-..."
 export GOOGLE_API_KEY="AI..."
@@ -23,153 +31,239 @@ export GOOGLE_API_KEY="AI..."
 
 ### Database Connection
 
-| Variable | Required | Default | Description |
-|----------|----------|---------|-------------|
-| `DATABASE_URL` | No | - | Default database connection URL |
+| Variable | Description |
+|----------|-------------|
+| `DATABASE_URL` | Default connection URL used by scripts or tools |
 
 Supported formats:
-```bash
-# PostgreSQL
-export DATABASE_URL="postgresql://user:pass@localhost:5432/dbname"
 
-# Amazon Redshift
-export DATABASE_URL="redshift://user:pass@cluster.region.redshift.amazonaws.com:5439/dbname"
+```bash
+export DATABASE_URL="postgresql://testuser:testpass@localhost:5432/testdb"
+export DATABASE_URL="redshift://user:pass@cluster.region.redshift.amazonaws.com:5439/analytics"
 ```
 
-### Schema Management
+### Retrieval and Cache Settings
 
-| Variable | Required | Default | Description |
-|----------|----------|---------|-------------|
-| `NLP2SQL_MAX_SCHEMA_TOKENS` | No | `8000` | Maximum tokens for schema context |
-| `NLP2SQL_SCHEMA_CACHE_TTL_HOURS` | No | `24` | Schema cache time-to-live in hours |
-| `NLP2SQL_EMBEDDINGS_DIR` | No | `./embeddings` | Directory for embedding cache storage |
-| `NLP2SQL_EMBEDDING_MODEL` | No | `all-MiniLM-L6-v2` | Local embedding model name |
-| `NLP2SQL_EMBEDDING_PROVIDER` | No | `local` | Embedding provider: `local` or `openai` |
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `NLP2SQL_MAX_SCHEMA_TOKENS` | `8000` | Maximum schema tokens sent to the model |
+| `NLP2SQL_SCHEMA_CACHE_TTL_HOURS` | `24` | Refresh window for schema caches |
+| `NLP2SQL_EMBEDDINGS_DIR` | `./embeddings` | Disk location for schema embedding caches |
+| `NLP2SQL_EXAMPLES_DIR` | implementation default | Disk location for example indexes |
+| `NLP2SQL_EMBEDDING_MODEL` | `all-MiniLM-L6-v2` | Default local embedding model |
+| `NLP2SQL_EMBEDDING_PROVIDER` | `local` | Default embedding provider |
 
 ```bash
-# Schema management settings
 export NLP2SQL_MAX_SCHEMA_TOKENS=8000
 export NLP2SQL_SCHEMA_CACHE_TTL_HOURS=24
-export NLP2SQL_EMBEDDINGS_DIR=/path/to/embeddings
+export NLP2SQL_EMBEDDINGS_DIR=/data/nlp2sql/embeddings
+export NLP2SQL_EXAMPLES_DIR=/data/nlp2sql/examples
 export NLP2SQL_EMBEDDING_MODEL=all-MiniLM-L6-v2
 export NLP2SQL_EMBEDDING_PROVIDER=local
 ```
 
-**Design rationale for key variables:**
+### Practical Notes
 
-- **`NLP2SQL_MAX_SCHEMA_TOKENS`** -- Limits the schema context sent to the AI provider. Higher values give the AI more schema information (better accuracy for complex joins) but cost more tokens. The default 8000 covers ~20-30 tables with full column definitions. For large schemas with many relevant tables, increase to 12000-16000.
-- **`NLP2SQL_SCHEMA_CACHE_TTL_HOURS`** -- Controls when the FAISS index and schema metadata are refreshed from the database. The 24h default balances freshness against the cost of re-querying system catalogs (especially expensive for Redshift's `SVV_TABLES`/`SVV_COLUMNS`). Set lower in development or when schema changes frequently.
-- **`NLP2SQL_EMBEDDINGS_DIR`** -- Where FAISS index files and TF-IDF metadata are stored on disk. Each database+schema combination gets its own subdirectory (MD5 hash of `{database_url}:{schema_name}`). Must be writable. In containerized environments (e.g., Claude Desktop MCP), the system falls back to `/tmp/nlp2sql_embeddings` if the default `./embeddings` is read-only.
-- **`NLP2SQL_EMBEDDING_MODEL`** -- The `sentence-transformers` model for local embeddings. `all-MiniLM-L6-v2` (384 dimensions) is a good balance of speed and quality. Changing this after an index is built requires clearing the cache (`nlp2sql cache clear --embeddings`) since dimensions must match.
+- `NLP2SQL_MAX_SCHEMA_TOKENS` controls how much schema detail can fit into the prompt after retrieval and compression.
+- `NLP2SQL_SCHEMA_CACHE_TTL_HOURS` affects when schema metadata and indexes are refreshed from the database.
+- `NLP2SQL_EMBEDDINGS_DIR` and `NLP2SQL_EXAMPLES_DIR` should point to persistent writable storage in long-lived deployments.
+- changing the embedding provider or model for an existing cache usually requires `nlp2sql cache clear --embeddings`
 
 ### General Settings
 
-| Variable | Required | Default | Description |
-|----------|----------|---------|-------------|
-| `NLP2SQL_LOG_LEVEL` | No | `INFO` | Logging level: `DEBUG`, `INFO`, `WARNING`, `ERROR` |
-| `NLP2SQL_CACHE_ENABLED` | No | `true` | Enable/disable query result caching |
-| `NLP2SQL_ENV` | No | - | Environment: `development`, `production` |
-| `TOKENIZERS_PARALLELISM` | No | - | Set to `false` to suppress tokenizer warnings |
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `NLP2SQL_LOG_LEVEL` | `INFO` | Logging verbosity |
+| `NLP2SQL_CACHE_ENABLED` | `true` | Enable or disable query-result caching |
+| `NLP2SQL_ENV` | unset | Optional environment label |
+| `TOKENIZERS_PARALLELISM` | unset | Set to `false` to reduce tokenizer warnings |
 
-```bash
-# General settings
-export NLP2SQL_LOG_LEVEL=INFO
-export NLP2SQL_CACHE_ENABLED=true
-export NLP2SQL_ENV=production
-export TOKENIZERS_PARALLELISM=false
-```
+## Semantic Context Guidance
 
-## Schema Filters
+Semantic context is not configured by environment variable. It is passed through the API or CLI and should be chosen intentionally per integration.
 
-Schema filters reduce the database schema to relevant tables for better performance and accuracy.
+### Use In-Memory Semantic Context When
 
-**Important:** Filters are applied *before* FAISS indexing (`SchemaManager._apply_schema_filters()` in `schema/manager.py`). Fewer elements indexed means faster semantic search and a more focused index. For enterprise databases (1000+ tables), well-chosen filters can reduce indexing time from minutes to seconds.
-
-### Filter Options
-
-| Filter | Type | Description |
-|--------|------|-------------|
-| `include_schemas` | `list[str]` | Only include these schemas |
-| `exclude_schemas` | `list[str]` | Exclude these schemas |
-| `include_tables` | `list[str]` | Only include these tables |
-| `exclude_tables` | `list[str]` | Exclude these tables |
-| `exclude_system_tables` | `bool` | Exclude PostgreSQL system tables |
-
-### Python Usage
+- you are integrating `nlp2sql` into an application or service
+- the semantic context is assembled from runtime state
+- you want the most idiomatic DSL usage
 
 ```python
-schema_filters = {
-    "include_schemas": ["sales", "finance"],
-    "exclude_schemas": ["archive", "temp"],
-    "include_tables": ["customers", "orders", "products"],
-    "exclude_tables": ["audit_logs", "migration_history"],
-    "exclude_system_tables": True
-}
-
-service = await create_and_initialize_service(
-    database_url="postgresql://localhost/db",
-    api_key=api_key,
-    schema_filters=schema_filters
+result = await nlp.ask(
+    "Show revenue by source category for the flagship store",
+    semantic_context=my_semantic_context,
 )
 ```
 
-### CLI Usage
+### Use File-Based Semantic Context When
+
+- you are testing from the CLI
+- you want versioned artifacts for experiments
+- you need a quick reproducible benchmark setup
 
 ```bash
 nlp2sql query \
-  --database-url postgresql://localhost/db \
-  --question "Show sales data" \
-  --schema-filters '{"include_schemas": ["sales"], "exclude_system_tables": true}'
+  --database-url "$DATABASE_URL" \
+  --question "Show revenue by source category for the flagship store" \
+  --semantic-context-file semantic-context.json
 ```
 
-### Filter Strategy by Database Size
+Both approaches end up producing the same runtime `SemanticContext`.
 
-| Database Size | Tables | Recommended Filters |
-|---------------|--------|---------------------|
-| Small | < 100 | No filtering needed |
-| Medium | 100-500 | `exclude_system_tables: true` |
-| Large | 500-1000 | Add `exclude_tables` for verbose tables |
-| Enterprise | 1000+ | Use `include_tables` for core entities (15-25 tables) |
+## Few-Shot Example Guidance
 
-## Provider Comparison
+Examples are also a runtime input, not a global environment setting.
 
-| Provider | Context Size | Cost/1K tokens | Best For |
-|----------|-------------|----------------|----------|
-| OpenAI GPT-4 | 128K | $0.030 | Complex reasoning |
-| Anthropic Claude | 200K | $0.015 | Large schemas |
-| Google Gemini | 1M | $0.001 | High volume, cost efficiency |
+### Python
 
-## Docker Test Databases
-
-For development and testing, use the included Docker Compose setup:
-
-```bash
-cd docker && docker-compose up -d
+```python
+nlp = await nlp2sql.connect(
+    database_url,
+    provider=provider_config,
+    examples=my_examples,
+)
 ```
 
-| Database | URL | Description |
-|----------|-----|-------------|
-| Simple | `postgresql://testuser:testpass@localhost:5432/testdb` | Small test database |
-| Enterprise | `postgresql://demo:demo123@localhost:5433/enterprise` | Large enterprise schema |
-| Redshift (LocalStack) | `redshift://testuser:testpass123@localhost:5439/testdb` | Redshift emulation |
-
-## Production Configuration Example
+### CLI
 
 ```bash
-# Production environment
+nlp2sql query \
+  --database-url "$DATABASE_URL" \
+  --question "Show revenue by source category for the flagship store" \
+  --examples-file examples.json
+```
+
+### How Examples Are Loaded
+
+When examples are provided:
+
+1. the library normalizes the payload
+2. embeddings are created using the configured embedding provider
+3. an example index is created or reused on disk
+4. relevant examples are selected at query time
+
+Because example indexes are embedding-provider specific, switching between `openai` and `local` without clearing the old index can produce a dimension mismatch.
+
+## Cache Behavior in Tests and Real Usage
+
+### In Tests
+
+Integration tests often isolate cache directories so runs do not interfere with each other. This is especially useful when:
+
+- mixing mock and real embedding providers
+- switching between local and OpenAI embeddings
+- running tests in parallel
+
+Typical pattern:
+
+```bash
+export NLP2SQL_EMBEDDINGS_DIR=/tmp/test-embeddings
+export NLP2SQL_EXAMPLES_DIR=/tmp/test-examples
+```
+
+### In Services
+
+Use stable persistent directories so schema and example indexes survive restarts:
+
+```bash
+export NLP2SQL_EMBEDDINGS_DIR=/var/lib/nlp2sql/embeddings
+export NLP2SQL_EXAMPLES_DIR=/var/lib/nlp2sql/examples
+```
+
+### In CI
+
+Use disposable cache directories unless you are explicitly testing warm-cache behavior.
+
+## Execution Mode Guidance
+
+The runtime has three practical execution modes.
+
+| Mode | When to use it |
+|------|----------------|
+| `generate_only` | fast generation, prompt iteration, or no execution port available |
+| `generate_and_validate` | safe validation of generated SQL against a readonly execution target |
+| `generate_validate_repair` | production-like usage where repair is worth the extra latency |
+
+### Python
+
+```python
+await nlp.ask("Count active users by region")
+await nlp.ask("Count active users by region", validate=True)
+await nlp.ask("Count active users by region", validate=True, repair=True)
+```
+
+### CLI
+
+```bash
+nlp2sql query --database-url "$DATABASE_URL" --question "Count active users by region"
+nlp2sql query --database-url "$DATABASE_URL" --question "Count active users by region" --validate
+nlp2sql query --database-url "$DATABASE_URL" --question "Count active users by region" --validate --repair
+```
+
+### What Changes Between Modes
+
+- `generate_only` returns the first generated SQL
+- `generate_and_validate` can surface execution validation metadata
+- `generate_validate_repair` can retry after semantic or runtime failures
+
+## Schema Filters
+
+Schema filters reduce retrieval scope before indexing and prompting.
+
+| Filter | Type | Description |
+|--------|------|-------------|
+| `include_schemas` | `list[str]` | Include only these schemas |
+| `exclude_schemas` | `list[str]` | Exclude these schemas |
+| `include_tables` | `list[str]` | Include only these tables |
+| `exclude_tables` | `list[str]` | Exclude these tables |
+| `exclude_system_tables` | `bool` | Exclude system relations |
+
+### Example
+
+```python
+schema_filters = {
+    "include_tables": ["stores", "marketing_channels", "daily_channel_metrics"],
+    "exclude_system_tables": True,
+}
+```
+
+Filters are applied before indexing, which keeps retrieval focused and lowers token usage.
+
+## Local Public Example Domain
+
+The repository ships a public e-commerce domain for documentation and integration tests.
+
+Start it with:
+
+```bash
+cd docker
+docker compose up -d postgres
+```
+
+Connection URL:
+
+```bash
+postgresql://testuser:testpass@localhost:5432/testdb
+```
+
+This is the recommended baseline for public experimentation.
+
+## Example Production Baseline
+
+```bash
 export NLP2SQL_ENV=production
 export NLP2SQL_LOG_LEVEL=INFO
 export NLP2SQL_CACHE_ENABLED=true
 export NLP2SQL_MAX_SCHEMA_TOKENS=8000
 export NLP2SQL_SCHEMA_CACHE_TTL_HOURS=24
-
-# AI Provider (choose one or more for fallback)
-export OPENAI_API_KEY="sk-prod-..."
-export ANTHROPIC_API_KEY="sk-ant-prod-..."
-
-# Database
-export DATABASE_URL="postgresql://prod-user:prod-pass@prod-host:5432/production"
-
-# Embedding storage (persistent volume in production)
 export NLP2SQL_EMBEDDINGS_DIR=/data/nlp2sql/embeddings
+export NLP2SQL_EXAMPLES_DIR=/data/nlp2sql/examples
+export OPENAI_API_KEY="sk-prod-..."
+export DATABASE_URL="postgresql://readonly-user:readonly-pass@warehouse-host:5432/analytics"
 ```
+
+## Related Docs
+
+- [README](../README.md)
+- [API Reference](API.md)
+- [Architecture](ARCHITECTURE.md)

--- a/docs/ENTERPRISE.md
+++ b/docs/ENTERPRISE.md
@@ -1,407 +1,244 @@
 # Enterprise Guide
 
-This document covers enterprise-specific features for large-scale production deployments and migration from other frameworks.
+This guide explains how to use `nlp2sql` in larger, governed environments without coupling the library to any private warehouse vocabulary.
 
-## Large Schema Management
+The recommended enterprise mindset is:
 
-### The Challenge: 1000+ Table Databases
+- use the DSL as the default integration surface
+- constrain schema scope aggressively
+- treat semantic context as a governed artifact
+- use validation and repair intentionally
 
-Enterprise databases often contain hundreds or thousands of tables. Traditional NLP-to-SQL approaches fail at this scale due to:
+## Recommended Integration Shape
 
-- **Token limitations**: Cannot fit entire schema in AI context
-- **Performance issues**: Slow schema processing and query generation
-- **Relevance problems**: AI gets confused by irrelevant tables
-- **Memory consumption**: Large schemas consume excessive memory
+In most services, initialize once and reuse the client:
 
-### Solution: Intelligent Schema Filtering
+```python
+import os
 
-nlp2sql uses multi-level filtering to handle large schemas efficiently.
+import nlp2sql
+from nlp2sql import ProviderConfig, SemanticContext
+
+
+nlp = await nlp2sql.connect(
+    os.environ["DATABASE_URL"],
+    provider=ProviderConfig(provider="openai", api_key=os.environ["OPENAI_API_KEY"]),
+    schema_filters={
+        "include_tables": ["stores", "marketing_channels", "daily_channel_metrics"],
+        "exclude_system_tables": True,
+    },
+    semantic_context=SemanticContext(
+        domain="ecommerce_channel_performance",
+        canonical_tables=["daily_channel_metrics"],
+    ),
+)
+```
+
+This gives one reusable client with stable retrieval artifacts and governed defaults.
+
+## Governed Usage Model
+
+Enterprise usage is not just about generating SQL. It is about shaping the meaning of requests before the model writes SQL.
+
+### The Governing Levers
+
+
+| Lever               | Purpose                                                 |
+| ------------------- | ------------------------------------------------------- |
+| schema filters      | limit what the system can see                           |
+| semantic context    | define canonical tables, metrics, dimensions, and rules |
+| examples            | show approved query patterns                            |
+| execution hooks     | validate and repair against a readonly target           |
+| metadata inspection | observe why a query was generated the way it was        |
+
+
+### Why Semantic Context Matters
+
+In larger systems, multiple tables may look plausible for the same question. Semantic context helps the library distinguish between:
+
+- canonical facts vs helper tables
+- approved metrics vs similarly named raw columns
+- required filters vs optional user hints
+- allowed tables vs legacy or deprecated relations
+
+That is the foundation for governed generation.
+
+## Large Schema Strategy
+
+### 1. Reduce Scope Early
 
 ```python
 schema_filters = {
-    # Schema-level filtering
-    "include_schemas": ["sales", "finance", "hr"],
-    "exclude_schemas": ["archive", "temp"],
-
-    # Table-level filtering
-    "include_tables": ["customers", "orders", "products"],
-    "exclude_tables": ["audit_logs", "migration_history"],
-    "exclude_system_tables": True
+    "include_tables": [
+        "stores",
+        "marketing_channels",
+        "daily_channel_metrics",
+        "orders",
+        "order_items",
+    ],
+    "exclude_system_tables": True,
 }
+```
 
-service = await create_and_initialize_service(
-    database_url="postgresql://enterprise-db/production",
-    ai_provider="anthropic",  # Best for large schemas (200K context)
-    api_key=api_key,
-    schema_filters=schema_filters
+Filters are applied before indexing, which improves speed and prompt quality.
+
+### 2. Add Semantic Context
+
+```python
+from nlp2sql import DimensionDefinition, DomainRule, MetricDefinition, SemanticContext
+
+semantic_context = SemanticContext(
+    domain="ecommerce_channel_performance",
+    canonical_tables=["daily_channel_metrics"],
+    metric_definitions=[
+        MetricDefinition(name="revenue", description="Daily revenue at the channel grain."),
+        MetricDefinition(name="orders_count", description="Daily order count at the channel grain."),
+    ],
+    dimension_definitions=[
+        DimensionDefinition(name="source_category", description="Marketing source grouping."),
+    ],
+    rules=[
+        DomainRule(
+            name="channel_breakdown_requires_source_category",
+            description="Use source_category whenever the question asks for channel or source breakdown.",
+            required_dimensions=["source_category"],
+            preferred_tables=["daily_channel_metrics"],
+        )
+    ],
 )
 ```
 
-### Vector Embeddings for Schema Relevance
+### 3. Add Approved Examples
 
-nlp2sql uses vector embeddings to automatically find the most relevant tables for each query:
+Examples should reinforce valid query shapes, not replace the semantic layer.
 
-```python
-# AI automatically identifies relevant tables
-question = "Show me sales performance by region"
-# Includes: sales_orders, territories, sales_reps
-# Excludes: hr_employees, finance_accounts, inventory_items
-```
+### 4. Enable Validation and Repair Selectively
 
-### Performance by Database Size
+Use `validate=True` when you have a safe readonly execution target.
 
-| Database Size | Tables | nlp2sql | Traditional Approach |
-|---------------|--------|---------|---------------------|
-| Small | 10-50 | < 1s | < 1s |
-| Medium | 100-500 | 1-3s | 5-15s |
-| Large | 1000+ | 3-8s | Timeout/Fail |
-| Enterprise | 5000+ | 5-15s | Not feasible |
+Use `repair=True` when:
 
----
+- the user flow benefits from automatic retry
+- extra latency is acceptable
+- you have enough observability to inspect failures
 
-## Multi-Provider Architecture
+## Multi-Provider Strategy
 
-### Avoiding Vendor Lock-in
+`nlp2sql` does not force a single provider. Typical strategies include:
 
-Most frameworks lock you into a single AI provider, creating risks:
-- **Cost risk**: Price changes affect entire system
-- **Performance risk**: No alternatives if service degrades
-- **Availability risk**: Outages affect entire system
+- one default provider for normal traffic
+- one higher-context provider for especially large schemas
+- benchmark-based provider selection before rollout
 
-### Multi-Provider Strategy
-
-```python
-async def robust_query_generation(question: str):
-    providers = ["openai", "anthropic", "gemini"]
-
-    for provider in providers:
-        try:
-            result = await generate_sql_from_db(
-                database_url=db_url,
-                question=question,
-                ai_provider=provider,
-                api_key=get_api_key(provider)
-            )
-            return result
-        except Exception as e:
-            logger.warning(f"Provider {provider} failed: {e}")
-            continue
-
-    raise Exception("All providers failed")
-```
-
-### Provider Selection by Use Case
-
-```python
-def select_optimal_provider(question: str, schema_size: int):
-    if schema_size > 1000:
-        return "anthropic"  # 200K context window
-    elif "complex" in question.lower():
-        return "openai"     # Best reasoning
-    else:
-        return "gemini"     # Most cost-effective
-```
-
-### Cost Comparison
-
-Use the built-in benchmarking to compare providers:
+Example benchmark:
 
 ```bash
 nlp2sql benchmark \
-  --database-url postgresql://localhost/db \
+  --database-url postgresql://testuser:testpass@localhost:5432/testdb \
   --providers openai,anthropic,gemini \
-  --questions test_queries.txt
+  --questions benchmark_questions.txt \
+  --examples-file examples.json \
+  --semantic-context-file semantic-context.json
 ```
 
----
+## Operational Guidance
 
-## Performance Optimization
+## Caching
 
-### Caching Layers
+Use persistent directories for:
 
-nlp2sql implements multiple caching layers:
+- schema embeddings
+- example indexes
 
-1. **Schema embedding cache**: Vector representations of table schemas, persistent across restarts
-2. **Query result cache**: Stores generated SQL for similar questions (reduces AI calls by 60-80%)
-3. **Provider response cache**: Handles rate limiting automatically
+Warm caches reduce startup work and improve steady-state latency.
 
-### Async Architecture
+## Observability
 
-```python
-# Concurrent query processing
-async def process_batch(questions: list[str]):
-    tasks = [service.generate_sql(q) for q in questions]
-    return await asyncio.gather(*tasks)
-```
+Capture at least:
 
-### Memory Optimization
+- question
+- generated SQL
+- provider
+- validation status
+- `semantic_context` metadata
+- `sql_intent_plan`
+- repair attempts
 
-- **Lazy loading**: Load schema elements only when needed
-- **Streaming processing**: Handle large schemas without memory spikes
-- **Connection pooling**: Efficient database connection management
+These fields are already exposed in `QueryResult.metadata`.
 
----
+## Security
 
-## Security and Compliance
+Recommended guardrails:
 
-### Data Privacy
+- connect through readonly credentials
+- exclude sensitive tables with schema filters
+- keep SQL safety checks enabled
+- use audit logging around generated SQL and metadata
 
-```python
-# Exclude sensitive tables from schema
-sensitive_filters = {
-    "exclude_tables": [
-        "user_passwords", "payment_tokens", "personal_data"
-    ]
-}
-```
-
-### SQL Injection Prevention
+Example:
 
 ```python
-result = await generate_sql(question)
-if not result['validation']['is_safe']:
-    raise SecurityError("Generated SQL contains unsafe patterns")
-```
-
-### Audit Logging
-
-```python
-audit_log = {
-    "timestamp": datetime.utcnow(),
-    "user": current_user.id,
+audit_record = {
     "question": question,
-    "generated_sql": result['sql'],
-    "provider": result['provider'],
-    "confidence": result['confidence']
+    "sql": result.sql,
+    "provider": result.provider,
+    "is_valid": result.is_valid,
+    "metadata": result.metadata,
 }
 ```
-
----
 
 ## Deployment Patterns
 
-### Microservice Architecture
+## API Service
 
 ```python
 from fastapi import FastAPI
-from nlp2sql import create_and_initialize_service
 
 app = FastAPI()
-service = None
 
-@app.on_event("startup")
-async def startup():
-    global service
-    service = await create_and_initialize_service(
-        database_url=os.getenv("DATABASE_URL"),
-        api_key=os.getenv("OPENAI_API_KEY")
-    )
 
 @app.post("/query")
-async def generate_query(question: str):
-    return await service.generate_sql(question)
+async def query(payload: dict[str, str]):
+    result = await nlp.ask(payload["question"], validate=True, repair=True)
+    return {"sql": result.sql, "metadata": result.metadata}
 ```
 
-### Kubernetes Deployment
+## Worker or Batch Process
 
-```yaml
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: nlp2sql-service
-spec:
-  replicas: 3
-  template:
-    spec:
-      containers:
-      - name: nlp2sql
-        image: nlp2sql:latest
-        env:
-        - name: DATABASE_URL
-          valueFrom:
-            secretKeyRef:
-              name: db-credentials
-              key: url
-        - name: OPENAI_API_KEY
-          valueFrom:
-            secretKeyRef:
-              name: ai-credentials
-              key: openai
-```
+Reuse a single initialized client per worker process and send multiple `ask()` calls through it.
 
-### AWS Lambda
+## Serverless
 
-```python
-import json
-from nlp2sql import generate_sql_from_db
+Possible, but less ideal when you depend on warm retrieval caches. If you use serverless, consider externalizing or warming cache directories when possible.
 
-def lambda_handler(event, context):
-    question = event['question']
-    result = await generate_sql_from_db(
-        database_url=os.environ['DATABASE_URL'],
-        question=question,
-        api_key=os.environ['OPENAI_API_KEY']
-    )
-    return {
-        'statusCode': 200,
-        'body': json.dumps(result)
-    }
-```
+## Migration Guidance
 
----
+If you already have a custom NL-to-SQL service, migrate in layers:
 
-## Migration Guide
+1. replace direct provider prompting with `connect()` and `ask()`
+2. add schema filters
+3. move business rules into `SemanticContext`
+4. add examples only after semantic scope is stable
+5. enable validation and repair
 
-### From Custom OpenAI Implementations
+That order keeps governance logic explicit and avoids overfitting to examples.
 
-**Before:**
-```python
-import openai
+## Public Example Domain
 
-class CustomNL2SQL:
-    def __init__(self, api_key: str, database_schema: dict):
-        self.client = openai.OpenAI(api_key=api_key)
-        self.schema = database_schema
+All public documentation examples in this repository use the local e-commerce schema:
 
-    def generate_sql(self, question: str) -> str:
-        prompt = self._build_prompt(question)
-        response = self.client.chat.completions.create(
-            model="gpt-4",
-            messages=[{"role": "user", "content": prompt}]
-        )
-        return response.choices[0].message.content
-```
+- `stores`
+- `marketing_channels`
+- `daily_channel_metrics`
+- `orders`
+- `order_items`
 
-**After:**
-```python
-from nlp2sql import create_and_initialize_service
+This keeps the enterprise guidance reproducible while still demonstrating realistic governance patterns.
 
-# Automatic schema loading and optimization
-service = await create_and_initialize_service(
-    database_url="postgresql://localhost/db",
-    api_key="your-openai-key"
-)
+## Related Docs
 
-result = await service.generate_sql("Show active users")
-sql = result['sql']
-confidence = result['confidence']
-is_valid = result['validation']['is_valid']
-```
+- [README](../README.md)
+- [Architecture](ARCHITECTURE.md)
+- [API Reference](API.md)
+- [Configuration](CONFIGURATION.md)
 
-### From Research Frameworks
-
-**Before:**
-```python
-from research_nl2sql import TaskChain, SchemaAnalyzer, QueryGenerator
-
-chain = TaskChain()
-chain.add_task(SchemaAnalyzer(embeddings_model="sentence-transformers"))
-chain.add_task(QueryGenerator(model="gpt-4"))
-result = chain.execute(question, schema)
-sql = result.tasks[-1].output.sql
-```
-
-**After:**
-```python
-from nlp2sql import generate_sql_from_db
-
-result = await generate_sql_from_db(
-    database_url="postgresql://localhost/db",
-    question=question,
-    ai_provider="openai",
-    api_key="your-api-key"
-)
-sql = result['sql']
-```
-
-### Migration Benefits
-
-- **90% less code** for common use cases
-- **Built-in optimizations**: caching, async, schema filtering
-- **Multi-provider support**: no vendor lock-in
-- **Production-ready**: error handling, monitoring
-
-### Step-by-Step Migration
-
-**Phase 1: Drop-in Replacement (1-2 days)**
-
-```bash
-pip install nlp2sql
-```
-
-```python
-# Replace basic calls
-# Old: sql = old_framework.generate(question, schema)
-# New:
-result = await generate_sql_from_db(db_url, question, api_key=key)
-sql = result['sql']
-```
-
-**Phase 2: Add Enterprise Features (1 week)**
-
-```python
-# Add schema filtering
-filters = {"exclude_system_tables": True}
-service = await create_and_initialize_service(db_url, schema_filters=filters)
-
-# Add multi-provider support
-benchmark_results = await benchmark_providers(db_url, test_questions)
-```
-
-**Phase 3: Optimization (2-4 weeks)**
-
-```python
-# Fine-tune filters for your database
-custom_filters = {
-    "include_schemas": ["sales", "finance"],
-    "include_tables": ["customers", "orders", "products"],
-    "exclude_system_tables": True
-}
-
-# Configure caching
-await service.configure_cache(ttl=3600, max_size=10000)
-```
-
-### Common Migration Issues
-
-**Issue: Schema format differences**
-Solution: nlp2sql auto-detects schema format - no manual formatting needed.
-
-**Issue: Different response format**
-Solution: Extract SQL from response dict:
-```python
-sql = result['sql']  # Extract just the SQL
-```
-
-**Issue: Synchronous to async**
-Solution: Use sync wrapper:
-```python
-import asyncio
-def generate_sql_sync(question: str) -> str:
-    return asyncio.run(generate_sql_from_db(db_url, question))['sql']
-```
-
----
-
-## Migration Checklist
-
-- [ ] Install nlp2sql
-- [ ] Test basic functionality with existing queries
-- [ ] Compare performance with current solution
-- [ ] Implement schema filtering for your database
-- [ ] Test multi-provider support
-- [ ] Add monitoring and logging
-- [ ] Optimize caching configuration
-- [ ] Train team on new features
-- [ ] Plan gradual rollout
-- [ ] Monitor production performance
-
-**Expected Results:**
-- 50-90% code reduction for common use cases
-- 2-5x performance improvement with caching
-- Better reliability with multi-provider fallbacks
-
----
-
-For configuration details, see [CONFIGURATION.md](CONFIGURATION.md).
-For API reference, see [API.md](API.md).

--- a/docs/Redshift.md
+++ b/docs/Redshift.md
@@ -1,208 +1,166 @@
 # Amazon Redshift Support
 
-nlp2sql provides comprehensive support for Amazon Redshift data warehouses, enabling natural language to SQL generation for enterprise analytics workloads. The implementation leverages Redshift's PostgreSQL compatibility while optimizing for data warehouse-specific features.
+`nlp2sql` supports Redshift as a first-class warehouse target while keeping the same DSL and semantic model used for PostgreSQL.
 
-## Features
+The public examples here stay generic and use the repository's own e-commerce-style concepts rather than any private warehouse naming.
 
-- **Native Redshift Support**: Direct connection using `redshift://` URLs
-- **PostgreSQL Compatibility**: Also accepts `postgresql://` connection strings
-- **Data Warehouse Optimizations**: Uses `svv_table_info` for accurate metadata
-- **Schema Filtering**: Advanced filtering for large enterprise schemas
-- **LocalStack Testing**: Complete testing infrastructure with Docker Compose
+## What Changes for Redshift
 
-## Getting Started
+At the API level, very little changes:
 
-### Python API
+- use a `redshift://` URL or a compatible PostgreSQL-style Redshift URL
+- keep using `connect()` and `ask()`
+- use schema filters aggressively on large warehouses
+- use semantic context when questions could map to multiple fact tables
+
+## Recommended Python Usage
 
 ```python
-import asyncio
 import os
-from nlp2sql import create_and_initialize_service, DatabaseType
 
-async def main():
-    # Connect to Amazon Redshift data warehouse
-    service = await create_and_initialize_service(
-        database_url="redshift://user:password@cluster.region.redshift.amazonaws.com:5439/analytics",
-        ai_provider="anthropic",  # Claude excels with large data warehouse schemas
-        api_key=os.getenv("ANTHROPIC_API_KEY"),
-        database_type=DatabaseType.REDSHIFT,
-        schema_filters={
-            "include_schemas": ["sales", "marketing", "finance"],
-            "exclude_system_tables": True,
-            "exclude_tables": ["temp_", "stg_", "test_"]  # Exclude staging/temp tables
-        }
-    )
-    
-    # Generate SQL optimized for Redshift analytics
-    result = await service.generate_sql(
-        question="What are the top 10 customer segments by revenue in Q4?",
-        database_type=DatabaseType.REDSHIFT
-    )
-    
-    print(f"Redshift SQL: {result['sql']}")
-    print(f"Confidence: {result['confidence']}")
+import nlp2sql
+from nlp2sql import ProviderConfig, SemanticContext
 
-asyncio.run(main())
+
+nlp = await nlp2sql.connect(
+    "redshift://user:password@cluster.region.redshift.amazonaws.com:5439/analytics",
+    provider=ProviderConfig(provider="anthropic", api_key=os.environ["ANTHROPIC_API_KEY"]),
+    schema="analytics",
+    schema_filters={
+        "include_tables": [
+            "stores",
+            "marketing_channels",
+            "daily_channel_metrics",
+        ],
+        "exclude_system_tables": True,
+    },
+    semantic_context=SemanticContext(
+        domain="ecommerce_channel_performance",
+        canonical_tables=["daily_channel_metrics"],
+    ),
+)
+
+result = await nlp.ask(
+    "Show daily revenue by source category for the flagship store",
+    validate=True,
+    repair=True,
+)
 ```
 
-### CLI Usage
+## Recommended CLI Usage
 
 ```bash
-# Basic Redshift query
 nlp2sql query \
-  --database-url redshift://user:pass@cluster.region.redshift.amazonaws.com:5439/analytics \
-  --question "What are our best performing product categories?" \
-  --provider anthropic
-
-# Query with schema filtering
-nlp2sql query \
-  --database-url redshift://user:pass@cluster.region.redshift.amazonaws.com:5439/analytics \
-  --question "Show quarterly sales trends" \
-  --schema-filters '{"include_schemas": ["sales", "analytics"]}'
-
-# Inspect Redshift schema
-nlp2sql inspect \
-  --database-url redshift://user:pass@cluster.region.redshift.amazonaws.com:5439/analytics \
-  --schema sales \
-  --format table
+  --database-url redshift://user:password@cluster.region.redshift.amazonaws.com:5439/analytics \
+  --schema analytics \
+  --provider anthropic \
+  --question "Show daily revenue by source category for the flagship store" \
+  --semantic-context-file semantic-context.json \
+  --examples-file examples.json \
+  --validate \
+  --repair \
+  --show-semantic-context \
+  --show-sql-intent-plan
 ```
 
-## Connection String Formats
+## Connection Formats
 
-**Standard Redshift Cluster:**
+Standard Redshift cluster:
+
 ```bash
 redshift://username:password@cluster-id.region.redshift.amazonaws.com:5439/database
 ```
 
-**Redshift Serverless:**
+Redshift Serverless:
+
 ```bash
 redshift://username:password@workgroup.account.region.redshift-serverless.amazonaws.com:5439/database
 ```
 
-**PostgreSQL-Compatible (also supported):**
+Compatible PostgreSQL-style URL:
+
 ```bash
 postgresql://username:password@cluster-id.region.redshift.amazonaws.com:5439/database
 ```
 
-## LocalStack Testing Infrastructure
+## Redshift Guidance
 
-For development and testing, nlp2sql includes a complete LocalStack setup that emulates Redshift behavior without requiring AWS resources.
+## 1. Keep Scope Small
 
-### Quick Start
+Warehouse schemas often contain staging, helper, and legacy tables. Prefer:
 
-```bash
-# Start LocalStack Redshift
-cd docker && docker-compose up -d localstack
+- `include_schemas`
+- `include_tables`
+- `exclude_tables`
+- `exclude_system_tables`
 
-# Run test script
-./test-redshift.sh
+This improves both retrieval quality and performance.
 
-# Query test data
-uv run nlp2sql query \
-  --database-url redshift://testuser:testpass123@localhost:5439/testdb \
-  --question "Show me all active users"
-```
+## 2. Use Semantic Context for Canonical Facts
 
-### LocalStack Examples
+If multiple Redshift tables could satisfy the same question, use semantic context to define:
 
-```bash
-# Basic Redshift query
-uv run nlp2sql query \
-  --database-url redshift://testuser:testpass123@localhost:5439/testdb \
-  --question "Show me all active users from the users table"
+- the canonical fact table
+- required dimensions
+- required filters
+- disallowed tables
 
-# Query with PostgreSQL-compatible URL
-uv run nlp2sql query \
-  --database-url postgresql://testuser:testpass123@localhost:5439/testdb \
-  --question "What are the top customers by transaction volume?" \
-  --explain
+This is usually more reliable than relying on examples alone.
 
-# Query specific schema in Redshift
-uv run nlp2sql query \
-  --database-url redshift://testuser:testpass123@localhost:5439/testdb \
-  --question "Show sales transactions by region" \
-  --schema-filters '{"include_schemas": ["sales"]}'
+## 3. Use Examples to Reinforce Approved Patterns
 
-# Inspect Redshift schema
-uv run nlp2sql inspect \
-  --database-url redshift://testuser:testpass123@localhost:5439/testdb \
-  --schema sales \
-  --format table
+Few-shot examples are still useful, especially when you need:
 
-# Test multi-schema Redshift queries
-uv run nlp2sql query \
-  --database-url redshift://testuser:testpass123@localhost:5439/testdb \
-  --question "Compare sales performance with analytics summary data" \
-  --schema-filters '{"include_schemas": ["sales", "analytics"]}'
-```
+- preferred join patterns
+- preferred date logic
+- preferred naming of derived metrics
 
-## Test Database Schema
+But examples work best when the semantic layer has already narrowed the solution space.
 
-The LocalStack Redshift instance includes a multi-schema test database:
+## Redshift-Specific Implementation Notes
 
-```
-testdb/
-├── public/
-│   ├── users (customer accounts)
-│   ├── products (product catalog)
-│   └── orders (customer orders)
-├── sales/
-│   ├── customers (customer master data)
-│   └── transactions (sales transactions)
-└── analytics/
-    └── sales_summary (aggregated metrics)
-```
-
-## Example Test Questions
-
-- "Show me all active users in the system"
-- "What are the top customers by transaction volume?"
-- "Calculate total revenue by sales rep"
-- "Show sales trends from the analytics summary"
-- "Which customers have the highest annual revenue?"
-- "Compare transaction amounts by product category"
-
-## Technical Implementation
-
-### Redshift-Specific Optimizations
-
-- **System Views**: Uses `svv_table_info` instead of PostgreSQL's `pg_stat_user_tables`
-- **Index Handling**: Simplified approach for Redshift's distribution and sort keys
-- **Connection Normalization**: Handles both native and PostgreSQL-compatible URLs
-- **Schema Filtering**: Optimized for data warehouse schemas with proper system table filtering
-
-### Database Type Detection
-
-The CLI automatically detects Redshift from connection URLs:
-- `redshift://` URLs automatically use `DatabaseType.REDSHIFT`
-- `postgresql://` URLs with Redshift hostnames are also supported
-- Manual override available with `--database-type` parameter
+- metadata discovery uses Redshift-appropriate system views
+- disk caching is especially helpful because warehouse catalog scans are relatively expensive
+- Redshift benefits more than small PostgreSQL databases from warm retrieval caches and strong schema filters
 
 ## Troubleshooting
 
-### Common Issues
+### Connection Errors
 
-1. **Connection Timeout**: Ensure your Redshift cluster allows connections from your IP
-2. **SSL Errors**: Redshift requires SSL by default, ensure your connection string includes appropriate SSL parameters
-3. **Schema Access**: Verify your user has read permissions on the schemas you want to query
-4. **LocalStack Issues**: Ensure Docker is running and LocalStack container is healthy
+Check:
 
-### Performance Tips
+- network access and allowlists
+- SSL requirements
+- schema permissions
+- readonly access for validation flows
 
-1. **Schema Filtering**: Use `include_schemas` to limit scope for faster metadata loading
-2. **Table Exclusion**: Exclude temporary and staging tables with `exclude_tables`
-3. **AI Provider**: Claude (Anthropic) often performs better with large data warehouse schemas
-4. **Connection Pooling**: For production use, consider connection pooling for better performance
+### Empty or Wrong Results
 
-## Security Considerations
+If SQL executes but the answer is semantically wrong:
 
-- Store credentials in environment variables, not in code
-- Use IAM roles when possible for AWS connections
-- Implement proper network security for Redshift access
-- Consider using Redshift's query logging for audit trails
+- inspect `semantic_context`
+- inspect `sql_intent_plan`
+- verify your schema filters are narrow enough
+- add or improve semantic context before adding more examples
 
-## Next Steps
+### Embedding Dimension Mismatch
 
-- See [API Reference](API.md) for Python API and CLI documentation
-- Check [Configuration](CONFIGURATION.md) for environment variables and schema filters
-- Review [examples/](../examples/) for more code samples
+If you see a message about index dimensions not matching the current embedding provider:
+
+```bash
+nlp2sql cache clear --embeddings
+```
+
+Then rerun with the intended embedding provider.
+
+## Local Testing
+
+The repository also includes local Redshift-oriented test infrastructure through Docker and LocalStack-style flows. Use that for development rather than depending on private infrastructure names in docs or examples.
+
+## Related Docs
+
+- [README](../README.md)
+- [Architecture](ARCHITECTURE.md)
+- [API Reference](API.md)
+- [Configuration](CONFIGURATION.md)
+

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,168 +1,155 @@
 # nlp2sql Examples
 
-This directory contains organized examples demonstrating various nlp2sql capabilities.
+This directory complements the main documentation. The recommended public baseline for examples is:
 
-## Getting Started
+- the DSL: `connect()` plus `ask()`
+- the repository's local e-commerce schema
+- optional semantic context
+- optional few-shot examples
 
-Start here if you're new to nlp2sql:
+## Public Baseline
 
-### [`getting_started/`](getting_started/)
-- **`test_api_setup.py`** - Validate API keys and environment setup
-- **`basic_usage.py`** - Comprehensive demo of all features
-- **`simple_demo.py`** - Minimal example for beginners
+All public-facing examples should stay aligned with the local e-commerce domain used in tests and docs:
 
-```bash
-# Test your setup first
-python examples/getting_started/test_api_setup.py
+- `stores`
+- `marketing_channels`
+- `users`
+- `products`
+- `orders`
+- `order_items`
+- `daily_channel_metrics`
 
-# Then try the basic example
-python examples/getting_started/basic_usage.py
-```
+This keeps the examples portable and avoids leaking any private warehouse vocabulary.
 
-## Advanced Features
+## Recommended Learning Path
 
-Explore advanced capabilities:
-
-### [`advanced/`](advanced/)
-- **`test_multiple_providers.py`** - Compare OpenAI, Anthropic, and Gemini
-- **`test_simple_api.py`** - One-line API usage patterns
+## 1. Start the Local Database
 
 ```bash
-# Test multiple AI providers
-python examples/advanced/test_multiple_providers.py
+cd docker
+docker compose up -d postgres
 ```
 
-## Schema Management
-
-Learn schema handling strategies:
-
-### [`schema_management/`](schema_management/)
-- **`test_auto_schema.py`** - Automatic schema loading from database
-- **`test_schema_filters_comprehensive.py`** - Complete schema filtering demo
+Default URL:
 
 ```bash
-# Test automatic schema discovery
-python examples/schema_management/test_auto_schema.py
+export DATABASE_URL="postgresql://testuser:testpass@localhost:5432/testdb"
 ```
 
-## Database-Specific
-
-Real-world database integrations:
-
-### [`database_specific/`](database_specific/)
-- **`test_odoo_integration.py`** - Comprehensive Odoo PostgreSQL integration
+## 2. Set a Provider Key
 
 ```bash
-# Test with Odoo database
-python examples/database_specific/test_odoo_integration.py
+export OPENAI_API_KEY="your-openai-key"
 ```
 
-## Documentation
+## 3. Start with the DSL
 
-Educational examples and guides:
+```python
+import nlp2sql
+from nlp2sql import ProviderConfig
 
-### [`documentation/`](documentation/)
-- **`real_world_example.py`** - Complete real-world scenario
 
-## Web API Integration
+nlp = await nlp2sql.connect(
+    database_url,
+    provider=ProviderConfig(provider="openai", api_key="sk-..."),
+)
 
-Production-ready web applications:
+result = await nlp.ask("Show active users by region")
+print(result.sql)
+```
 
-### [`strands-fastapi-agent/`](strands-fastapi-agent/)
-- Complete FastAPI application with Strands Agents integration
-- Natural language database queries via REST API
-- Docker deployment with PostgreSQL
-- Swagger UI documentation included
-- Sub-10ms query performance
-- 25-table e-commerce schema
+## 4. Add Semantic Context
+
+Use semantic context when the same question could map to multiple tables or business meanings.
+
+```python
+from nlp2sql import SemanticContext
+
+result = await nlp.ask(
+    "Show revenue by source category for the flagship store",
+    semantic_context=SemanticContext(
+        domain="ecommerce_channel_performance",
+        canonical_tables=["daily_channel_metrics"],
+    ),
+)
+```
+
+## 5. Add Examples
+
+Examples should support the semantic layer, not replace it.
+
+```python
+examples = [
+    {
+        "question": "Show revenue by source category for the flagship store",
+        "sql": "SELECT ...",
+        "database_type": "postgres",
+    }
+]
+
+nlp = await nlp2sql.connect(
+    database_url,
+    provider=ProviderConfig(provider="openai", api_key="sk-..."),
+    examples=examples,
+)
+```
+
+## CLI Equivalents
+
+The same concepts are available from the CLI:
 
 ```bash
-# Quick start with Docker
-cd examples/strands-fastapi-agent
-docker-compose up -d --build
-
-# Test the API
-./test-docker-endpoints.sh
-
-# Access Swagger UI
-open http://localhost:8000/docs
+nlp2sql query \
+  --database-url "$DATABASE_URL" \
+  --question "Show revenue by source category for the flagship store" \
+  --validate \
+  --repair
 ```
 
-**Features:**
-- Strands AI agents with tool calling
-- Multiple API endpoints (direct tools + agent)
-- Comprehensive documentation (1500+ lines)
-- Production-ready Docker setup
-- Automated test suite
-
-## Environment Setup
-
-Before running examples, set up your environment:
+With semantic context and examples:
 
 ```bash
-# Required for OpenAI (default provider)
-export OPENAI_API_KEY=your-openai-key
-
-# Optional for multi-provider support
-export ANTHROPIC_API_KEY=your-anthropic-key
-export GOOGLE_API_KEY=your-google-key
-
-# Database connection (for database examples)
-export DATABASE_URL=postgresql://user:pass@localhost:5432/db
+nlp2sql query \
+  --database-url "$DATABASE_URL" \
+  --question "Show revenue by source category for the flagship store" \
+  --examples-file examples.json \
+  --semantic-context-file semantic-context.json \
+  --validate \
+  --repair \
+  --show-semantic-context \
+  --show-sql-intent-plan \
+  --show-selected-examples
 ```
 
-## Example Workflow
+## Example Categories
 
-1. **Setup & Validation**
-   ```bash
-   python examples/getting_started/test_api_setup.py
-   ```
+Use the subdirectories here as implementation references, but keep new public examples aligned with the DSL-first model and the local e-commerce domain.
 
-2. **Learn Basics**
-   ```bash
-   python examples/getting_started/simple_demo.py
-   python examples/getting_started/basic_usage.py
-   ```
+Useful categories include:
 
-3. **Explore Advanced Features**
-   ```bash
-   python examples/advanced/test_multiple_providers.py
-   ```
+- getting started
+- advanced provider comparison
+- schema management
+- API service integration
 
-4. **Database Integration**
-   ```bash
-   python examples/database_specific/test_odoo_integration.py
-   ```
+## Writing New Public Examples
 
-## Troubleshooting
+Prefer examples that:
 
-### Common Issues
+- use `connect()` and `ask()`
+- reference local e-commerce tables only
+- show semantic context explicitly when business meaning matters
+- demonstrate `validate` and `repair` when execution behavior is relevant
 
-**API Key Errors:**
-```bash
-# Run the setup test to diagnose
-python examples/getting_started/test_api_setup.py
-```
+Avoid examples that:
 
-**Database Connection:**
-```bash
-# Check your database URL format
-postgresql://username:password@host:port/database
-```
+- depend on private schema names
+- assume unreproducible external warehouse state
+- rely only on examples when semantic context is the real governing mechanism
 
-**Import Errors:**
-```bash
-# Install missing providers
-pip install nlp2sql[anthropic,gemini]
-# Or install all providers
-pip install nlp2sql[all-providers]
-```
+## Related Docs
 
-## Performance Tips
-
-1. **Use Pre-Initialized Services** for multiple queries
-2. **Apply Schema Filters** for large databases
-3. **Cache Service Instances** in production
-4. **Choose the Right Provider** for your use case
-
-See the [API Reference](../docs/API.md) for detailed usage patterns and [Configuration](../docs/CONFIGURATION.md) for environment setup.
+- [README](../README.md)
+- [API Reference](../docs/API.md)
+- [Architecture](../docs/ARCHITECTURE.md)
+- [Configuration](../docs/CONFIGURATION.md)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nlp2sql"
-version = "0.2.0rc12"
+version = "0.2.0rc13"
 description = "Enterprise-ready Natural Language to SQL converter with multi-provider support. Built for production scale (1000+ tables) with Clean Architecture."
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/nlp2sql/__init__.py
+++ b/src/nlp2sql/__init__.py
@@ -1,26 +1,52 @@
 """nlp2sql - Natural Language to SQL converter with multiple AI providers."""
 
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 
 from .adapters.openai_adapter import OpenAIAdapter
 from .adapters.postgres_repository import PostgreSQLRepository
 from .adapters.redshift_adapter import RedshiftRepository
+from .adapters.default_error_classifier import DefaultErrorClassifier
+from .adapters.default_repair_policy import DefaultRepairPolicy
+from .adapters.dict_semantic_resolver import DictSemanticResolver
+from .adapters.file_semantic_resolver import FileSemanticResolver
+from .adapters.noop_semantic_resolver import NoOpSemanticResolver
+from .adapters.noop_semantic_validator import NoOpSemanticValidator
+from .adapters.schema_repository_execution_adapter import SchemaRepositoryExecutionAdapter
 from .config.settings import settings
 from .client import NLP2SQL, connect
-from .core.entities import DatabaseType, Query, SQLQuery
+from .core.entities import (
+    CanonicalQueryPattern,
+    DatabaseType,
+    DimensionDefinition,
+    DomainRule,
+    MetricDefinition,
+    Query,
+    SQLQuery,
+    SemanticContext,
+    SemanticEntityMapping,
+    SemanticIssue,
+    SemanticValidationResult,
+    SqlIntentPlan,
+)
 from .core.provider_config import ProviderConfig
 from .core.result import QueryResult
+from .core.runtime import ExecutionHooks, ExecutionMode, SemanticHooks
 from .exceptions import *
 from .factories import RepositoryFactory
 from .ports.embedding_provider import EmbeddingProviderPort
 from .ports.example_repository import ExampleRepositoryPort
+from .ports.error_classifier import ErrorClassifierPort
+from .ports.query_execution import QueryExecutionPort
 from .ports.query_safety import QuerySafetyPort
 from .ports.query_validator import QueryValidatorPort
+from .ports.repair_policy import RepairPolicyPort
 from .ports.schema_repository import SchemaRepositoryPort
+from .ports.semantic_resolver import SemanticResolverPort
+from .ports.semantic_validator import SemanticValidatorPort
 from .schema.example_store import ExampleStore
 from .services.query_service import QueryGenerationService
 
-__version__ = "0.2.0rc12"
+__version__ = "0.2.0rc13"
 __author__ = "Luis Carbonel"
 __email__ = "devhighlevel@gmail.com"
 
@@ -29,6 +55,9 @@ __all__ = [
     "connect",
     "NLP2SQL",
     "QueryResult",
+    "ExecutionHooks",
+    "ExecutionMode",
+    "SemanticHooks",
     # Main service (advanced)
     "QueryGenerationService",
     # Legacy helpers (still work, prefer connect())
@@ -48,14 +77,35 @@ __all__ = [
     "ProviderConfig",
     "Query",
     "SQLQuery",
+    "SemanticContext",
+    "SemanticEntityMapping",
+    "MetricDefinition",
+    "DimensionDefinition",
+    "DomainRule",
+    "CanonicalQueryPattern",
+    "SqlIntentPlan",
+    "SemanticIssue",
+    "SemanticValidationResult",
     # Embedding Provider
     "EmbeddingProviderPort",
     # Example Repository
     "ExampleRepositoryPort",
     "ExampleStore",
+    "QueryExecutionPort",
+    "ErrorClassifierPort",
+    "RepairPolicyPort",
+    "SemanticResolverPort",
+    "SemanticValidatorPort",
     # Query Safety & Validation
     "QuerySafetyPort",
     "QueryValidatorPort",
+    "SchemaRepositoryExecutionAdapter",
+    "DefaultErrorClassifier",
+    "DefaultRepairPolicy",
+    "NoOpSemanticResolver",
+    "NoOpSemanticValidator",
+    "DictSemanticResolver",
+    "FileSemanticResolver",
     # Configuration
     "settings",
     # Exceptions
@@ -157,11 +207,16 @@ def create_query_service(
     api_key: Optional[str] = None,
     model: Optional[str] = None,
     database_type: DatabaseType = DatabaseType.POSTGRES,
-    schema_filters: Optional[Dict[str, Any]] = None,
-    embedding_provider: Optional[EmbeddingProviderPort] = None,
+    schema_filters: dict[str, Any] | None = None,
+    embedding_provider: EmbeddingProviderPort | None = None,
     embedding_provider_type: Optional[str] = None,
     schema_name: str = "public",
-    example_store: Optional[ExampleRepositoryPort] = None,
+    example_store: ExampleRepositoryPort | None = None,
+    execution_port: QueryExecutionPort | None = None,
+    error_classifier: ErrorClassifierPort | None = None,
+    repair_policy: RepairPolicyPort | None = None,
+    semantic_resolver: SemanticResolverPort | None = None,
+    semantic_validator: SemanticValidatorPort | None = None,
     *,
     provider_config: Optional[ProviderConfig] = None,
 ) -> QueryGenerationService:
@@ -217,7 +272,7 @@ def create_query_service(
         _max_tokens = None
 
     # Build adapter kwargs — only pass non-None values so adapters use their own defaults
-    adapter_kwargs: Dict[str, Any] = {"api_key": _api_key}
+    adapter_kwargs: dict[str, Any] = {"api_key": _api_key}
     if _model is not None:
         adapter_kwargs["model"] = _model
     if _temperature is not None:
@@ -276,7 +331,14 @@ def create_query_service(
     query_validator = RegexQueryValidator()
 
     # Create service
-    service = QueryGenerationService(
+    if execution_port is None:
+        execution_port = SchemaRepositoryExecutionAdapter(repository)
+    if error_classifier is None:
+        error_classifier = DefaultErrorClassifier()
+    if repair_policy is None:
+        repair_policy = DefaultRepairPolicy(max_attempts=settings.retry_attempts)
+
+    return QueryGenerationService(
         ai_provider=provider,
         schema_repository=repository,
         schema_filters=schema_filters,
@@ -284,9 +346,12 @@ def create_query_service(
         schema_name=schema_name,
         example_store=example_store,
         query_validator=query_validator,
+        execution_port=execution_port,
+        error_classifier=error_classifier,
+        repair_policy=repair_policy,
+        semantic_resolver=semantic_resolver,
+        semantic_validator=semantic_validator,
     )
-
-    return service
 
 
 async def create_and_initialize_service(
@@ -295,11 +360,16 @@ async def create_and_initialize_service(
     api_key: Optional[str] = None,
     model: Optional[str] = None,
     database_type: DatabaseType = DatabaseType.POSTGRES,
-    schema_filters: Optional[Dict[str, Any]] = None,
-    embedding_provider: Optional[EmbeddingProviderPort] = None,
+    schema_filters: dict[str, Any] | None = None,
+    embedding_provider: EmbeddingProviderPort | None = None,
     embedding_provider_type: Optional[str] = None,
     schema_name: str = "public",
-    example_store: Optional[ExampleRepositoryPort] = None,
+    example_store: ExampleRepositoryPort | None = None,
+    execution_port: QueryExecutionPort | None = None,
+    error_classifier: ErrorClassifierPort | None = None,
+    repair_policy: RepairPolicyPort | None = None,
+    semantic_resolver: SemanticResolverPort | None = None,
+    semantic_validator: SemanticValidatorPort | None = None,
     *,
     provider_config: Optional[ProviderConfig] = None,
 ) -> QueryGenerationService:
@@ -346,6 +416,11 @@ async def create_and_initialize_service(
         embedding_provider_type,
         schema_name,
         example_store,
+        execution_port,
+        error_classifier,
+        repair_policy,
+        semantic_resolver,
+        semantic_validator,
         provider_config=provider_config,
     )
     await service.initialize(database_type)
@@ -359,11 +434,16 @@ async def generate_sql_from_db(
     api_key: Optional[str] = None,
     model: Optional[str] = None,
     database_type: DatabaseType = DatabaseType.POSTGRES,
-    schema_filters: Optional[Dict[str, Any]] = None,
-    embedding_provider: Optional[EmbeddingProviderPort] = None,
+    schema_filters: dict[str, Any] | None = None,
+    embedding_provider: EmbeddingProviderPort | None = None,
     embedding_provider_type: Optional[str] = None,
     schema_name: str = "public",
-    example_store: Optional[ExampleRepositoryPort] = None,
+    example_store: ExampleRepositoryPort | None = None,
+    execution_port: QueryExecutionPort | None = None,
+    error_classifier: ErrorClassifierPort | None = None,
+    repair_policy: RepairPolicyPort | None = None,
+    semantic_resolver: SemanticResolverPort | None = None,
+    semantic_validator: SemanticValidatorPort | None = None,
     *,
     provider_config: Optional[ProviderConfig] = None,
     **kwargs,
@@ -414,6 +494,11 @@ async def generate_sql_from_db(
         embedding_provider_type,
         schema_name,
         example_store,
+        execution_port,
+        error_classifier,
+        repair_policy,
+        semantic_resolver,
+        semantic_validator,
         provider_config=provider_config,
     )
     return await service.generate_sql(question=question, database_type=database_type, **kwargs)

--- a/src/nlp2sql/adapters/anthropic_adapter.py
+++ b/src/nlp2sql/adapters/anthropic_adapter.py
@@ -11,6 +11,7 @@ from ..config.settings import settings
 from ..exceptions import ProviderException, TokenLimitException
 from ..ports.ai_provider import AIProviderPort, AIProviderType, QueryContext, QueryResponse
 from ..utils.helpers import first_not_none
+from ..utils.semantic_prompt import format_semantic_context_lines, format_sql_intent_plan_lines
 
 logger = structlog.get_logger()
 
@@ -126,10 +127,34 @@ class AnthropicAdapter(AIProviderPort):
     def _build_prompt(self, context: QueryContext) -> str:
         """Build prompt for query generation."""
         prompt_parts = []
+        metadata = context.metadata or {}
 
         # Add context
         prompt_parts.append(f"Database Type: {context.database_type}")
         prompt_parts.append(f"Question: {context.question}")
+
+        intent_context = metadata.get("intent_context")
+        if isinstance(intent_context, dict):
+            prompt_parts.append("Intent Context:")
+            prompt_parts.append(f"- Intent: {intent_context.get('intent', 'unknown')}")
+            if intent_context.get("metrics"):
+                prompt_parts.append(f"- Metrics: {', '.join(intent_context['metrics'])}")
+            if intent_context.get("dimensions"):
+                prompt_parts.append(f"- Dimensions: {', '.join(intent_context['dimensions'])}")
+            if intent_context.get("time_grains"):
+                prompt_parts.append(f"- Time grains: {', '.join(intent_context['time_grains'])}")
+            if intent_context.get("filters"):
+                prompt_parts.append(f"- Filters: {', '.join(intent_context['filters'])}")
+            if intent_context.get("expected_operations"):
+                prompt_parts.append(f"- Expected operations: {', '.join(intent_context['expected_operations'])}")
+
+        semantic_context = metadata.get("semantic_context")
+        if isinstance(semantic_context, dict) and semantic_context:
+            prompt_parts.extend(format_semantic_context_lines(semantic_context))
+
+        sql_intent_plan = metadata.get("sql_intent_plan")
+        if isinstance(sql_intent_plan, dict) and sql_intent_plan:
+            prompt_parts.extend(format_sql_intent_plan_lines(sql_intent_plan))
 
         # Add schema context
         if context.schema_context:
@@ -138,10 +163,15 @@ class AnthropicAdapter(AIProviderPort):
         # Add examples
         if context.examples:
             prompt_parts.append("Examples:")
-            for i, example in enumerate(context.examples[:3], 1):
+            for i, example in enumerate(context.examples[: settings.max_prompt_examples], 1):
                 prompt_parts.append(f"Example {i}:")
                 prompt_parts.append(f"Question: {example['question']}")
                 prompt_parts.append(f"SQL: {example['sql']}")
+                example_metadata = example.get("metadata", {})
+                if isinstance(example_metadata, dict):
+                    tables = example_metadata.get("tables")
+                    if tables:
+                        prompt_parts.append(f"Tables: {', '.join(tables)}")
                 prompt_parts.append("")
 
         # Add instructions

--- a/src/nlp2sql/adapters/default_error_classifier.py
+++ b/src/nlp2sql/adapters/default_error_classifier.py
@@ -1,0 +1,65 @@
+"""Default execution error classifier."""
+
+from __future__ import annotations
+
+from ..core.entities import DatabaseType, ExecutionErrorInfo
+from ..ports.error_classifier import ErrorClassifierPort
+
+
+class DefaultErrorClassifier(ErrorClassifierPort):
+    """Classify common SQL execution errors into repair-friendly buckets."""
+
+    def classify(
+        self,
+        error_message: str,
+        database_type: DatabaseType,
+        sql: str,
+    ) -> ExecutionErrorInfo:
+        lowered = error_message.lower()
+
+        if any(token in lowered for token in ("column", "does not exist", "unknown column")):
+            return ExecutionErrorInfo(
+                category="missing_column",
+                message=error_message,
+                retryable=True,
+                hints=["Verify exact column names from the schema.", "Avoid inferring columns not present in the schema."],
+            )
+        if any(token in lowered for token in ("relation", "table", "view", "not found")):
+            return ExecutionErrorInfo(
+                category="missing_table",
+                message=error_message,
+                retryable=True,
+                hints=["Use only tables present in the retrieved schema context.", "Check schema prefixes if needed."],
+            )
+        if any(token in lowered for token in ("function", "not supported", "syntax error", "parse error")):
+            hints = ["Regenerate using syntax supported by the target database."]
+            if database_type == DatabaseType.REDSHIFT:
+                hints.append("For Redshift avoid INTERVAL arithmetic, TRUNC(date, format), DISTINCT ON, and STRING_AGG.")
+            return ExecutionErrorInfo(
+                category="function_not_supported",
+                message=error_message,
+                retryable=True,
+                hints=hints,
+            )
+        if any(token in lowered for token in ("permission", "access denied", "not authorized")):
+            return ExecutionErrorInfo(
+                category="permission",
+                message=error_message,
+                retryable=False,
+                hints=["Choose accessible tables and columns only when the schema/context indicates they are available."],
+            )
+        if "timeout" in lowered:
+            return ExecutionErrorInfo(
+                category="timeout",
+                message=error_message,
+                retryable=True,
+                hints=["Prefer simpler aggregations, fewer joins, and explicit limits."],
+            )
+
+        return ExecutionErrorInfo(
+            category="execution_error",
+            message=error_message,
+            retryable=True,
+            hints=["Regenerate the SQL with a simpler query shape and stricter adherence to the schema context."],
+            metadata={"sql_preview": sql[:120]},
+        )

--- a/src/nlp2sql/adapters/default_repair_policy.py
+++ b/src/nlp2sql/adapters/default_repair_policy.py
@@ -1,0 +1,41 @@
+"""Default repair policy for execution-aware query generation."""
+
+from __future__ import annotations
+
+from ..core.entities import DatabaseType, ExecutionErrorInfo, RepairDecision
+from ..ports.repair_policy import RepairPolicyPort
+
+
+class DefaultRepairPolicy(RepairPolicyPort):
+    """Retry only for errors likely to be fixed by regeneration."""
+
+    def __init__(self, max_attempts: int = 2):
+        self.max_attempts = max_attempts
+
+    def decide(
+        self,
+        error: ExecutionErrorInfo,
+        database_type: DatabaseType,
+        attempt: int,
+    ) -> RepairDecision:
+        del database_type
+
+        if attempt >= self.max_attempts:
+            return RepairDecision(
+                should_retry=False,
+                max_attempts=self.max_attempts,
+                reason="repair_attempt_limit_reached",
+            )
+
+        if not error.retryable:
+            return RepairDecision(
+                should_retry=False,
+                max_attempts=self.max_attempts,
+                reason=f"non_retryable:{error.category}",
+            )
+
+        return RepairDecision(
+            should_retry=True,
+            max_attempts=self.max_attempts,
+            reason=f"retryable:{error.category}",
+        )

--- a/src/nlp2sql/adapters/dict_semantic_resolver.py
+++ b/src/nlp2sql/adapters/dict_semantic_resolver.py
@@ -1,0 +1,27 @@
+"""Simple semantic resolver backed by a dictionary or SemanticContext."""
+
+from __future__ import annotations
+
+from ..core.entities import DatabaseType, RetrievalPlan, SemanticContext
+from ..ports.semantic_resolver import SemanticResolverPort
+from ..utils.artifact_loader import semantic_context_from_dict
+
+
+class DictSemanticResolver(SemanticResolverPort):
+    """Resolve semantics from a preloaded dict or SemanticContext."""
+
+    def __init__(self, semantic_definition: SemanticContext | dict[str, object]):
+        if isinstance(semantic_definition, SemanticContext):
+            self._semantic_context = semantic_definition
+        else:
+            self._semantic_context = semantic_context_from_dict(semantic_definition)
+
+    async def resolve(
+        self,
+        question: str,
+        retrieval_plan: RetrievalPlan,
+        database_type: DatabaseType,
+        semantic_context: SemanticContext | None = None,
+    ) -> SemanticContext:
+        del question, retrieval_plan, database_type, semantic_context
+        return self._semantic_context

--- a/src/nlp2sql/adapters/file_semantic_resolver.py
+++ b/src/nlp2sql/adapters/file_semantic_resolver.py
@@ -1,0 +1,24 @@
+"""Simple semantic resolver backed by a JSON/YAML file."""
+
+from __future__ import annotations
+
+from ..core.entities import DatabaseType, RetrievalPlan, SemanticContext
+from ..ports.semantic_resolver import SemanticResolverPort
+from ..utils.artifact_loader import load_semantic_context
+
+
+class FileSemanticResolver(SemanticResolverPort):
+    """Resolve semantics from a JSON/YAML semantic context file."""
+
+    def __init__(self, file_path: str):
+        self._semantic_context = load_semantic_context(file_path=file_path)
+
+    async def resolve(
+        self,
+        question: str,
+        retrieval_plan: RetrievalPlan,
+        database_type: DatabaseType,
+        semantic_context: SemanticContext | None = None,
+    ) -> SemanticContext:
+        del question, retrieval_plan, database_type, semantic_context
+        return self._semantic_context or SemanticContext()

--- a/src/nlp2sql/adapters/gemini_adapter.py
+++ b/src/nlp2sql/adapters/gemini_adapter.py
@@ -12,6 +12,7 @@ from ..config.settings import settings
 from ..exceptions import ProviderException, TokenLimitException
 from ..ports.ai_provider import AIProviderPort, AIProviderType, QueryContext, QueryResponse
 from ..utils.helpers import first_not_none
+from ..utils.semantic_prompt import format_semantic_context_lines, format_sql_intent_plan_lines
 
 logger = structlog.get_logger()
 
@@ -138,10 +139,34 @@ class GeminiAdapter(AIProviderPort):
     def _build_prompt(self, context: QueryContext) -> str:
         """Build prompt for query generation."""
         prompt_parts = []
+        metadata = context.metadata or {}
 
         # Add context
         prompt_parts.append(f"Database Type: {context.database_type}")
         prompt_parts.append(f"Question: {context.question}")
+
+        intent_context = metadata.get("intent_context")
+        if isinstance(intent_context, dict):
+            prompt_parts.append("Intent Context:")
+            prompt_parts.append(f"- Intent: {intent_context.get('intent', 'unknown')}")
+            if intent_context.get("metrics"):
+                prompt_parts.append(f"- Metrics: {', '.join(intent_context['metrics'])}")
+            if intent_context.get("dimensions"):
+                prompt_parts.append(f"- Dimensions: {', '.join(intent_context['dimensions'])}")
+            if intent_context.get("time_grains"):
+                prompt_parts.append(f"- Time grains: {', '.join(intent_context['time_grains'])}")
+            if intent_context.get("filters"):
+                prompt_parts.append(f"- Filters: {', '.join(intent_context['filters'])}")
+            if intent_context.get("expected_operations"):
+                prompt_parts.append(f"- Expected operations: {', '.join(intent_context['expected_operations'])}")
+
+        semantic_context = metadata.get("semantic_context")
+        if isinstance(semantic_context, dict) and semantic_context:
+            prompt_parts.extend(format_semantic_context_lines(semantic_context))
+
+        sql_intent_plan = metadata.get("sql_intent_plan")
+        if isinstance(sql_intent_plan, dict) and sql_intent_plan:
+            prompt_parts.extend(format_sql_intent_plan_lines(sql_intent_plan))
 
         # Add schema context
         if context.schema_context:
@@ -150,10 +175,15 @@ class GeminiAdapter(AIProviderPort):
         # Add examples
         if context.examples:
             prompt_parts.append("Examples:")
-            for i, example in enumerate(context.examples[:3], 1):
+            for i, example in enumerate(context.examples[: settings.max_prompt_examples], 1):
                 prompt_parts.append(f"Example {i}:")
                 prompt_parts.append(f"Question: {example['question']}")
                 prompt_parts.append(f"SQL: {example['sql']}")
+                example_metadata = example.get("metadata", {})
+                if isinstance(example_metadata, dict):
+                    tables = example_metadata.get("tables")
+                    if tables:
+                        prompt_parts.append(f"Tables: {', '.join(tables)}")
                 prompt_parts.append("")
 
         # Add instructions

--- a/src/nlp2sql/adapters/noop_semantic_resolver.py
+++ b/src/nlp2sql/adapters/noop_semantic_resolver.py
@@ -1,0 +1,20 @@
+"""No-op semantic resolver used when no business context source is configured."""
+
+from __future__ import annotations
+
+from ..core.entities import DatabaseType, RetrievalPlan, SemanticContext
+from ..ports.semantic_resolver import SemanticResolverPort
+
+
+class NoOpSemanticResolver(SemanticResolverPort):
+    """Return the provided semantic context unchanged."""
+
+    async def resolve(
+        self,
+        question: str,
+        retrieval_plan: RetrievalPlan,
+        database_type: DatabaseType,
+        semantic_context: SemanticContext | None = None,
+    ) -> SemanticContext:
+        del question, retrieval_plan, database_type
+        return semantic_context or SemanticContext()

--- a/src/nlp2sql/adapters/noop_semantic_validator.py
+++ b/src/nlp2sql/adapters/noop_semantic_validator.py
@@ -1,0 +1,19 @@
+"""No-op semantic validator used when no custom validator is configured."""
+
+from __future__ import annotations
+
+from ..core.entities import SemanticContext, SemanticValidationResult, SqlIntentPlan
+from ..ports.semantic_validator import SemanticValidatorPort
+
+
+class NoOpSemanticValidator(SemanticValidatorPort):
+    """Always returns a valid semantic validation result."""
+
+    async def validate(
+        self,
+        sql: str,
+        semantic_context: SemanticContext,
+        sql_intent_plan: SqlIntentPlan | None = None,
+    ) -> SemanticValidationResult:
+        del sql, semantic_context, sql_intent_plan
+        return SemanticValidationResult(is_valid=True)

--- a/src/nlp2sql/adapters/openai_adapter.py
+++ b/src/nlp2sql/adapters/openai_adapter.py
@@ -12,6 +12,7 @@ from ..config.settings import settings
 from ..exceptions import ProviderException, TokenLimitException
 from ..ports.ai_provider import AIProviderPort, AIProviderType, QueryContext, QueryResponse
 from ..utils.helpers import first_not_none
+from ..utils.semantic_prompt import format_semantic_context_lines, format_sql_intent_plan_lines
 
 logger = structlog.get_logger()
 
@@ -159,10 +160,34 @@ class OpenAIAdapter(AIProviderPort):
     def _build_prompt(self, context: QueryContext) -> str:
         """Build prompt for query generation."""
         prompt_parts = []
+        metadata = context.metadata or {}
 
         # Add context
         prompt_parts.append(f"Database Type: {context.database_type}")
         prompt_parts.append(f"Question: {context.question}")
+
+        intent_context = metadata.get("intent_context")
+        if isinstance(intent_context, dict):
+            prompt_parts.append("Intent Context:")
+            prompt_parts.append(f"- Intent: {intent_context.get('intent', 'unknown')}")
+            if intent_context.get("metrics"):
+                prompt_parts.append(f"- Metrics: {', '.join(intent_context['metrics'])}")
+            if intent_context.get("dimensions"):
+                prompt_parts.append(f"- Dimensions: {', '.join(intent_context['dimensions'])}")
+            if intent_context.get("time_grains"):
+                prompt_parts.append(f"- Time grains: {', '.join(intent_context['time_grains'])}")
+            if intent_context.get("filters"):
+                prompt_parts.append(f"- Filters: {', '.join(intent_context['filters'])}")
+            if intent_context.get("expected_operations"):
+                prompt_parts.append(f"- Expected operations: {', '.join(intent_context['expected_operations'])}")
+
+        semantic_context = metadata.get("semantic_context")
+        if isinstance(semantic_context, dict) and semantic_context:
+            prompt_parts.extend(format_semantic_context_lines(semantic_context))
+
+        sql_intent_plan = metadata.get("sql_intent_plan")
+        if isinstance(sql_intent_plan, dict) and sql_intent_plan:
+            prompt_parts.extend(format_sql_intent_plan_lines(sql_intent_plan))
 
         # Add schema context
         if context.schema_context:
@@ -171,10 +196,15 @@ class OpenAIAdapter(AIProviderPort):
         # Add examples
         if context.examples:
             prompt_parts.append("Examples:")
-            for i, example in enumerate(context.examples[:3], 1):
+            for i, example in enumerate(context.examples[: settings.max_prompt_examples], 1):
                 prompt_parts.append(f"Example {i}:")
                 prompt_parts.append(f"Question: {example['question']}")
                 prompt_parts.append(f"SQL: {example['sql']}")
+                example_metadata = example.get("metadata", {})
+                if isinstance(example_metadata, dict):
+                    tables = example_metadata.get("tables")
+                    if tables:
+                        prompt_parts.append(f"Tables: {', '.join(tables)}")
                 prompt_parts.append("")
 
         # Add instructions

--- a/src/nlp2sql/adapters/schema_repository_execution_adapter.py
+++ b/src/nlp2sql/adapters/schema_repository_execution_adapter.py
@@ -1,0 +1,20 @@
+"""Adapter that exposes a SchemaRepository as a QueryExecutionPort."""
+
+from __future__ import annotations
+
+from ..ports.query_execution import QueryExecutionPort
+from ..ports.schema_repository import SchemaRepositoryPort
+
+
+class SchemaRepositoryExecutionAdapter(QueryExecutionPort):
+    """Execute generated SQL through the active schema repository."""
+
+    def __init__(self, repository: SchemaRepositoryPort):
+        self.repository = repository
+
+    async def execute_readonly(
+        self,
+        sql: str,
+        timeout_seconds: int = 30,
+    ) -> dict[str, object]:
+        return await self.repository.execute_query(sql=sql, timeout_seconds=timeout_seconds)

--- a/src/nlp2sql/cli.py
+++ b/src/nlp2sql/cli.py
@@ -14,8 +14,14 @@ import structlog
 
 from . import create_and_initialize_service, create_query_service
 from .core.entities import DatabaseType
+from .core.runtime import ExecutionMode
 from .core.provider_config import ProviderConfig
 from .exceptions import NLP2SQLException, ProviderException
+from .utils.artifact_loader import (
+    create_example_store_from_payload,
+    load_examples_payload,
+    load_semantic_context,
+)
 
 
 def get_embeddings_dir() -> Path:
@@ -84,6 +90,45 @@ def validate_database_url(ctx, param, value):
         click.echo("   redshift://user:pass@cluster.region.redshift.amazonaws.com:5439/database", err=True)
         ctx.exit(1)
     return value
+
+
+def parse_schema_filters(schema_filters: str | None) -> dict | None:
+    """Parse schema filters JSON passed via CLI."""
+    if not schema_filters:
+        return None
+    try:
+        return json.loads(schema_filters)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Invalid JSON in schema-filters: {exc.msg}.") from exc
+
+
+def resolve_execution_mode(validate: bool, repair: bool) -> str:
+    """Resolve CLI validate/repair flags into the public execution mode."""
+    if repair:
+        return ExecutionMode.GENERATE_VALIDATE_REPAIR.value
+    if validate:
+        return ExecutionMode.GENERATE_AND_VALIDATE.value
+    return ExecutionMode.GENERATE_ONLY.value
+
+
+def echo_runtime_metadata(
+    result: dict,
+    *,
+    show_semantic_context: bool,
+    show_sql_intent_plan: bool,
+    show_selected_examples: bool,
+) -> None:
+    """Print optional semantic/runtime metadata sections."""
+    metadata = result.get("metadata", {})
+    if show_semantic_context and metadata.get("semantic_context"):
+        click.echo("\nSemantic Context:")
+        click.echo(json.dumps(metadata["semantic_context"], indent=2))
+    if show_sql_intent_plan and metadata.get("sql_intent_plan"):
+        click.echo("\nSQL Intent Plan:")
+        click.echo(json.dumps(metadata["sql_intent_plan"], indent=2))
+    if show_selected_examples and metadata.get("selected_examples"):
+        click.echo("\nSelected Examples:")
+        click.echo(json.dumps(metadata["selected_examples"], indent=2))
 
 
 @click.group()
@@ -296,6 +341,15 @@ def inspect(
 @click.option("--temperature", type=float, default=0.1, help="Model temperature (0.0-1.0)")
 @click.option("--max-tokens", type=int, default=1000, help="Maximum tokens for response")
 @click.option("--schema-filters", help="JSON string with schema filters")
+@click.option("--semantic-context-file", type=click.Path(exists=True), help="Path to semantic context JSON/YAML")
+@click.option("--semantic-context-json", help="Inline semantic context JSON")
+@click.option("--examples-file", type=click.Path(exists=True), help="Path to few-shot examples JSON/YAML")
+@click.option("--examples-json", help="Inline few-shot examples JSON")
+@click.option("--show-semantic-context", is_flag=True, help="Print the semantic context used at runtime")
+@click.option("--show-sql-intent-plan", is_flag=True, help="Print the SQL intent plan built for the question")
+@click.option("--show-selected-examples", is_flag=True, help="Print metadata for selected few-shot examples")
+@click.option("--validate", "run_validation", is_flag=True, help="Execute generated SQL for validation")
+@click.option("--repair", is_flag=True, help="Retry with repair on execution or semantic failures")
 @click.option(
     "--embedding-provider",
     type=click.Choice(["auto", "local", "openai", "none"]),
@@ -315,6 +369,15 @@ def query(
     temperature: float,
     max_tokens: int,
     schema_filters: Optional[str],
+    semantic_context_file: Optional[str],
+    semantic_context_json: Optional[str],
+    examples_file: Optional[str],
+    examples_json: Optional[str],
+    show_semantic_context: bool,
+    show_sql_intent_plan: bool,
+    show_selected_examples: bool,
+    run_validation: bool,
+    repair: bool,
     embedding_provider: str,
 ):
     """Generate SQL from natural language question with advanced options."""
@@ -328,14 +391,7 @@ def query(
                 click.echo(f"🌡️  Temperature: {temperature}")
                 click.echo(f"📏 Max tokens: {max_tokens}")
 
-            # Parse schema filters if provided
-            filters = None
-            if schema_filters:
-                try:
-                    filters = json.loads(schema_filters)
-                except json.JSONDecodeError:
-                    click.echo("[ERROR] Invalid JSON in schema-filters", err=True)
-                    sys.exit(1)
+            filters = parse_schema_filters(schema_filters)
 
             # Get API key from parameter or environment
             final_api_key = api_key
@@ -366,6 +422,23 @@ def query(
             else:
                 embedding_provider_type = embedding_provider  # "local" or "openai"
 
+            semantic_context = load_semantic_context(
+                file_path=semantic_context_file,
+                inline_json=semantic_context_json,
+            )
+            examples_payload = load_examples_payload(
+                file_path=examples_file,
+                inline_json=examples_json,
+                database_type=database_type,
+            )
+            example_store = await create_example_store_from_payload(
+                examples=examples_payload,
+                database_url=database_url,
+                schema_name=schema,
+                embedding_provider_type=embedding_provider_type,
+                api_key=final_api_key,
+            )
+
             # Build unified provider config
             provider_config = ProviderConfig(
                 provider=provider,
@@ -383,6 +456,7 @@ def query(
                 schema_filters=filters,
                 schema_name=schema,
                 embedding_provider_type=embedding_provider_type,
+                example_store=example_store,
             )
 
             # Generate SQL
@@ -392,6 +466,8 @@ def query(
                 temperature=temperature,
                 max_tokens=max_tokens,
                 include_explanation=explain,
+                execution_mode=resolve_execution_mode(run_validation, repair),
+                semantic_context=semantic_context,
             )
 
             # Output results
@@ -410,6 +486,13 @@ def query(
                     click.echo("[OK] SQL validation: Passed")
                 else:
                     click.echo(f"[WARNING] SQL validation issues: {validation.get('issues', [])}")
+
+            echo_runtime_metadata(
+                result,
+                show_semantic_context=show_semantic_context,
+                show_sql_intent_plan=show_sql_intent_plan,
+                show_selected_examples=show_selected_examples,
+            )
 
         except ProviderException as e:
             click.echo(f"[ERROR] Provider Error: {e!s}", err=True)
@@ -727,34 +810,49 @@ def providers_test(provider):
 
 
 @cli.command()
-@click.option("--database-url", required=True, help="Database connection URL")
+@click.option("--database-url", required=True, callback=validate_database_url, help="Database connection URL")
+@click.option("--schema", default="public", help="Database schema name")
 @click.option("--questions", help="File with test questions (one per line)")
 @click.option("--providers", help="Comma-separated list of providers to test")
 @click.option("--iterations", type=int, default=3, help="Number of iterations per test")
 @click.option("--schema-filters", help="JSON string with schema filters")
+@click.option("--semantic-context-file", type=click.Path(exists=True), help="Path to semantic context JSON/YAML")
+@click.option("--semantic-context-json", help="Inline semantic context JSON")
+@click.option("--examples-file", type=click.Path(exists=True), help="Path to few-shot examples JSON/YAML")
+@click.option("--examples-json", help="Inline few-shot examples JSON")
+@click.option(
+    "--embedding-provider",
+    type=click.Choice(["auto", "local", "openai", "none"]),
+    default="auto",
+    help="Embedding provider for schema/examples: 'auto', 'local', 'openai', or 'none'",
+)
 @click.option("--output-file", type=click.Path(), help="Output file to save benchmark results (JSON format)")
 @click.pass_context
 def benchmark(
     ctx,
     database_url: str,
+    schema: str,
     questions: Optional[str],
     providers: Optional[str],
     iterations: int,
     schema_filters: Optional[str],
+    semantic_context_file: Optional[str],
+    semantic_context_json: Optional[str],
+    examples_file: Optional[str],
+    examples_json: Optional[str],
+    embedding_provider: str,
     output_file: Optional[str],
 ):
     """Benchmark different AI providers performance."""
     verbose = ctx.obj.get("verbose", False)
 
     async def _benchmark():
-        # Parse schema filters if provided
-        filters = None
-        if schema_filters:
-            try:
-                filters = json.loads(schema_filters)
-            except json.JSONDecodeError:
-                click.echo("[ERROR] Invalid JSON in schema-filters", err=True)
-                sys.exit(1)
+        filters = parse_schema_filters(schema_filters)
+        database_type = detect_database_type(database_url)
+        semantic_context = load_semantic_context(
+            file_path=semantic_context_file,
+            inline_json=semantic_context_json,
+        )
 
         # Default test questions
         default_questions = [
@@ -819,15 +917,48 @@ def benchmark(
             api_key = os.getenv(env_var)
 
             try:
+                if embedding_provider == "none":
+                    embedding_provider_type = None
+                elif embedding_provider == "auto":
+                    embedding_provider_type = "local"
+                else:
+                    embedding_provider_type = embedding_provider
+
+                examples_payload = load_examples_payload(
+                    file_path=examples_file,
+                    inline_json=examples_json,
+                    database_type=database_type,
+                )
+                example_store = await create_example_store_from_payload(
+                    examples=examples_payload,
+                    database_url=database_url,
+                    schema_name=schema,
+                    embedding_provider_type=embedding_provider_type,
+                    api_key=api_key,
+                )
+                provider_config = ProviderConfig(
+                    provider=provider,
+                    api_key=api_key,
+                )
                 service = await create_and_initialize_service(
-                    database_url=database_url, ai_provider=provider, api_key=api_key, schema_filters=filters
+                    database_url=database_url,
+                    provider_config=provider_config,
+                    database_type=database_type,
+                    schema_filters=filters,
+                    schema_name=schema,
+                    embedding_provider_type=embedding_provider_type,
+                    example_store=example_store,
                 )
 
                 for question in test_questions:
                     for iteration in range(iterations):
                         try:
                             start_time = time.time()
-                            result = await service.generate_sql(question=question, database_type=DatabaseType.POSTGRES)
+                            result = await service.generate_sql(
+                                question=question,
+                                database_type=database_type,
+                                semantic_context=semantic_context,
+                            )
                             end_time = time.time()
 
                             provider_results["total_time"] += end_time - start_time

--- a/src/nlp2sql/client.py
+++ b/src/nlp2sql/client.py
@@ -16,11 +16,17 @@ from typing import Any, Optional
 
 import structlog
 
-from .core.entities import DatabaseType
+from .core.entities import DatabaseType, SemanticContext
 from .core.provider_config import ProviderConfig
 from .core.result import QueryResult
+from .core.runtime import ExecutionHooks, ExecutionMode, SemanticHooks
 from .ports.embedding_provider import EmbeddingProviderPort
+from .ports.error_classifier import ErrorClassifierPort
 from .ports.example_repository import ExampleRepositoryPort
+from .ports.query_execution import QueryExecutionPort
+from .ports.repair_policy import RepairPolicyPort
+from .ports.semantic_resolver import SemanticResolverPort
+from .ports.semantic_validator import SemanticValidatorPort
 from .services.query_service import QueryGenerationService
 
 logger = structlog.get_logger()
@@ -37,9 +43,11 @@ class NLP2SQL:
         self,
         service: QueryGenerationService,
         database_type: DatabaseType,
+        semantic_context: SemanticContext | None = None,
     ) -> None:
         self._service = service
         self._database_type = database_type
+        self._semantic_context = semantic_context
 
     # ------------------------------------------------------------------
     # DSL methods
@@ -50,6 +58,11 @@ class NLP2SQL:
         question: str,
         *,
         explain: bool = True,
+        execution_mode: ExecutionMode | str | None = None,
+        validate: bool = False,
+        repair: bool = False,
+        timeout_seconds: int = 30,
+        semantic_context: SemanticContext | None = None,
     ) -> QueryResult:
         """Convert a natural language question to SQL.
 
@@ -64,8 +77,26 @@ class NLP2SQL:
             question=question,
             database_type=self._database_type,
             include_explanation=explain,
+            execution_mode=self._resolve_execution_mode(execution_mode, validate=validate, repair=repair),
+            timeout_seconds=timeout_seconds,
+            semantic_context=semantic_context or self._semantic_context,
         )
         return QueryResult.from_dict(raw)
+
+    def _resolve_execution_mode(
+        self,
+        execution_mode: ExecutionMode | str | None,
+        *,
+        validate: bool,
+        repair: bool,
+    ) -> str:
+        if execution_mode is not None:
+            return execution_mode.value if isinstance(execution_mode, ExecutionMode) else execution_mode
+        if repair:
+            return ExecutionMode.GENERATE_VALIDATE_REPAIR.value
+        if validate:
+            return ExecutionMode.GENERATE_AND_VALIDATE.value
+        return ExecutionMode.GENERATE_ONLY.value
 
     async def validate(self, sql: str) -> dict[str, Any]:
         """Validate a SQL query against the loaded schema."""
@@ -102,6 +133,14 @@ async def connect(
     embedding_provider: Optional[EmbeddingProviderPort] = None,
     embedding_provider_type: Optional[str] = None,
     examples: Optional[ExampleRepositoryPort | list[dict[str, Any]]] = None,
+    hooks: ExecutionHooks | None = None,
+    semantic_hooks: SemanticHooks | None = None,
+    execution_port: Optional[QueryExecutionPort] = None,
+    error_classifier: Optional[ErrorClassifierPort] = None,
+    repair_policy: Optional[RepairPolicyPort] = None,
+    semantic_resolver: Optional[SemanticResolverPort] = None,
+    semantic_validator: Optional[SemanticValidatorPort] = None,
+    semantic_context: SemanticContext | None = None,
 ) -> NLP2SQL:
     """Connect to a database and return a ready-to-use NLP2SQL client.
 
@@ -119,6 +158,8 @@ async def connect(
             - A list of dicts ``[{"question": ..., "sql": ..., "database_type": ...}]``
               (auto-creates an ExampleStore with OpenAI embeddings)
             - A pre-built ``ExampleRepositoryPort`` instance
+        hooks: Grouped execution hooks for validation/repair in the public DSL.
+        semantic_hooks: Grouped semantic hooks for business-aware retrieval and validation.
 
     Returns:
         An initialized ``NLP2SQL`` client ready for ``ask()`` calls.
@@ -176,6 +217,15 @@ async def connect(
     if embedding_provider is None and embedding_provider_type is None and provider is not None:
         embedding_provider_type = provider.provider
 
+    if hooks is not None:
+        execution_port = execution_port or hooks.execution_port
+        error_classifier = error_classifier or hooks.error_classifier
+        repair_policy = repair_policy or hooks.repair_policy
+    if semantic_hooks is not None:
+        semantic_resolver = semantic_resolver or semantic_hooks.semantic_resolver
+        semantic_validator = semantic_validator or semantic_hooks.semantic_validator
+        semantic_context = semantic_context or semantic_hooks.semantic_context
+
     service = await create_and_initialize_service(
         database_url=database_url,
         database_type=database_type,
@@ -185,6 +235,11 @@ async def connect(
         embedding_provider_type=embedding_provider_type,
         example_store=example_store,
         provider_config=provider,
+        execution_port=execution_port,
+        error_classifier=error_classifier,
+        repair_policy=repair_policy,
+        semantic_resolver=semantic_resolver,
+        semantic_validator=semantic_validator,
     )
 
-    return NLP2SQL(service=service, database_type=database_type)
+    return NLP2SQL(service=service, database_type=database_type, semantic_context=semantic_context)

--- a/src/nlp2sql/config/settings.py
+++ b/src/nlp2sql/config/settings.py
@@ -29,7 +29,7 @@ class Settings(BaseSettings):
 
     # General settings
     app_name: str = "nlp2sql"
-    version: str = "0.2.0rc8"
+    version: str = "0.2.0rc13"
     debug: bool = Field(default=False, validation_alias="NLP2SQL_DEBUG")
     log_level: LogLevel = Field(default=LogLevel.INFO, validation_alias="NLP2SQL_LOG_LEVEL")
 
@@ -63,6 +63,7 @@ class Settings(BaseSettings):
     default_temperature: float = Field(default=0.1, validation_alias="NLP2SQL_TEMPERATURE")
     default_max_tokens: int = Field(default=2000, validation_alias="NLP2SQL_MAX_TOKENS")
     max_examples: int = Field(default=5, validation_alias="NLP2SQL_MAX_EXAMPLES")
+    max_prompt_examples: int = Field(default=3, validation_alias="NLP2SQL_MAX_PROMPT_EXAMPLES")
     retry_attempts: int = Field(default=3, validation_alias="NLP2SQL_RETRY_ATTEMPTS")
     retry_delay_seconds: float = Field(default=1.0, validation_alias="NLP2SQL_RETRY_DELAY")
 

--- a/src/nlp2sql/core/database_prompts.py
+++ b/src/nlp2sql/core/database_prompts.py
@@ -31,7 +31,9 @@ DATABASE_SQL_HINTS: dict[str, str] = {
         "7) generate_series() is not supported - use CTEs or date tables for sequences. "
         "8) No ARRAY types or ARRAY_AGG - use SUPER type for semi-structured data. "
         "9) Use APPROXIMATE COUNT(DISTINCT col) for large cardinality counts. "
-        "10) Avoid SELECT * - only select needed columns for columnar storage efficiency."
+        "10) Prefer QUALIFY with ROW_NUMBER() when filtering window-function results. "
+        "11) Avoid SELECT * - only select needed columns for columnar storage efficiency. "
+        "12) Do not use unsupported PostgreSQL idioms such as NOW(), STRING_AGG, or INTERVAL literals."
     ),
 }
 

--- a/src/nlp2sql/core/entities.py
+++ b/src/nlp2sql/core/entities.py
@@ -1,6 +1,6 @@
 """Core domain entities for nlp2sql."""
 
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
 from datetime import datetime
 from enum import Enum
 from typing import Any, Dict, List, Optional
@@ -89,4 +89,244 @@ class QueryExample:
     intent: QueryIntent
     complexity: int  # 1-5 scale
     tags: List[str] = field(default_factory=list)
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class QueryIntentContext:
+    """Structured understanding of a natural language analytics question."""
+
+    intent: QueryIntent
+    business_terms: List[str] = field(default_factory=list)
+    metrics: List[str] = field(default_factory=list)
+    dimensions: List[str] = field(default_factory=list)
+    time_grains: List[str] = field(default_factory=list)
+    filters: List[str] = field(default_factory=list)
+    expected_operations: List[str] = field(default_factory=list)
+    requires_aggregation: bool = False
+    requires_join: bool = False
+    requires_ordering: bool = False
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class RetrievalPlan:
+    """Signals shared across schema retrieval and example selection."""
+
+    original_question: str
+    normalized_question: str
+    intent_context: QueryIntentContext
+    retrieval_query: str
+    example_query: str
+    keyword_hints: List[str] = field(default_factory=list)
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class SemanticEntityMapping:
+    """Resolved business term mapped to a concrete SQL concept."""
+
+    source_term: str
+    target: str
+    resolved_value: str
+    filter_expression: Optional[str] = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def to_prompt_text(self) -> str:
+        if self.filter_expression:
+            return f"{self.source_term} -> {self.filter_expression}"
+        return f"{self.source_term} -> {self.target} = {self.resolved_value}"
+
+
+@dataclass
+class MetricDefinition:
+    """Canonical business metric description."""
+
+    name: str
+    expression: Optional[str] = None
+    description: Optional[str] = None
+    source_columns: List[str] = field(default_factory=list)
+    synonyms: List[str] = field(default_factory=list)
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class DimensionDefinition:
+    """Canonical business dimension description."""
+
+    name: str
+    expression: Optional[str] = None
+    description: Optional[str] = None
+    synonyms: List[str] = field(default_factory=list)
+    allowed_values: List[str] = field(default_factory=list)
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class DomainRule:
+    """Business guardrails that constrain SQL generation."""
+
+    name: str
+    description: str
+    required_filters: List[str] = field(default_factory=list)
+    preferred_tables: List[str] = field(default_factory=list)
+    disallowed_tables: List[str] = field(default_factory=list)
+    required_dimensions: List[str] = field(default_factory=list)
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class CanonicalQueryPattern:
+    """Reference query shape for a business domain."""
+
+    name: str
+    description: str
+    canonical_sql: Optional[str] = None
+    preferred_tables: List[str] = field(default_factory=list)
+    metric_names: List[str] = field(default_factory=list)
+    dimension_names: List[str] = field(default_factory=list)
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class SemanticContext:
+    """Resolved business semantic context for a question."""
+
+    domain: Optional[str] = None
+    entity_mappings: List[SemanticEntityMapping] = field(default_factory=list)
+    metric_definitions: List[MetricDefinition] = field(default_factory=list)
+    dimension_definitions: List[DimensionDefinition] = field(default_factory=list)
+    canonical_tables: List[str] = field(default_factory=list)
+    supporting_tables: List[str] = field(default_factory=list)
+    required_filters: List[str] = field(default_factory=list)
+    preferred_time_logic: List[str] = field(default_factory=list)
+    disallowed_tables: List[str] = field(default_factory=list)
+    prompt_hints: List[str] = field(default_factory=list)
+    rules: List[DomainRule] = field(default_factory=list)
+    patterns: List[CanonicalQueryPattern] = field(default_factory=list)
+    confidence: float = 0.0
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def is_empty(self) -> bool:
+        return not any(
+            [
+                self.domain,
+                self.entity_mappings,
+                self.metric_definitions,
+                self.dimension_definitions,
+                self.canonical_tables,
+                self.supporting_tables,
+                self.required_filters,
+                self.preferred_time_logic,
+                self.disallowed_tables,
+                self.prompt_hints,
+                self.rules,
+                self.patterns,
+            ]
+        )
+
+    def to_metadata(self) -> Dict[str, Any]:
+        payload = asdict(self)
+        payload["entity_mappings"] = [
+            {
+                **asdict(mapping),
+                "prompt_text": mapping.to_prompt_text(),
+            }
+            for mapping in self.entity_mappings
+        ]
+        return payload
+
+
+@dataclass
+class SqlIntentPlan:
+    """Structured plan that narrows the space before SQL generation."""
+
+    domain: Optional[str] = None
+    fact_table: Optional[str] = None
+    supporting_tables: List[str] = field(default_factory=list)
+    dimensions: List[str] = field(default_factory=list)
+    metrics: List[str] = field(default_factory=list)
+    filters: List[str] = field(default_factory=list)
+    time_range: Optional[str] = None
+    group_by: List[str] = field(default_factory=list)
+    order_by: List[str] = field(default_factory=list)
+    semantic_context_ref: Optional[str] = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def to_metadata(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class SemanticIssue:
+    """Semantic issue detected before or after SQL generation."""
+
+    category: str
+    message: str
+    severity: str = "error"
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class SemanticValidationResult:
+    """Result of semantic validation rules."""
+
+    is_valid: bool = True
+    issues: List[SemanticIssue] = field(default_factory=list)
+    warnings: List[str] = field(default_factory=list)
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def to_metadata(self) -> Dict[str, Any]:
+        return {
+            "is_valid": self.is_valid,
+            "issues": [asdict(issue) for issue in self.issues],
+            "warnings": list(self.warnings),
+            "metadata": dict(self.metadata),
+        }
+
+
+@dataclass
+class ExampleCandidate:
+    """Normalized example candidate produced by selection/reranking."""
+
+    question: str
+    sql: str
+    score: float
+    tables: List[str] = field(default_factory=list)
+    intent: Optional[QueryIntent] = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class ExecutionErrorInfo:
+    """Classified execution error used by repair policies."""
+
+    category: str
+    message: str
+    retryable: bool
+    hints: List[str] = field(default_factory=list)
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class RepairDecision:
+    """Decision returned by a repair policy."""
+
+    should_retry: bool
+    max_attempts: int
+    reason: str
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class RepairContext:
+    """Context passed into the repair loop."""
+
+    original_question: str
+    database_type: DatabaseType
+    previous_sql: str
+    error: ExecutionErrorInfo
+    attempt: int
+    schema_context: str
+    examples: List[Dict[str, Any]] = field(default_factory=list)
     metadata: Dict[str, Any] = field(default_factory=dict)

--- a/src/nlp2sql/core/runtime.py
+++ b/src/nlp2sql/core/runtime.py
@@ -1,0 +1,39 @@
+"""Public runtime configuration helpers for the high-level DSL."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+from ..core.entities import SemanticContext
+from ..ports.error_classifier import ErrorClassifierPort
+from ..ports.query_execution import QueryExecutionPort
+from ..ports.repair_policy import RepairPolicyPort
+from ..ports.semantic_resolver import SemanticResolverPort
+from ..ports.semantic_validator import SemanticValidatorPort
+
+
+class ExecutionMode(str, Enum):
+    """Execution modes exposed by the public DSL."""
+
+    GENERATE_ONLY = "generate_only"
+    GENERATE_AND_VALIDATE = "generate_and_validate"
+    GENERATE_VALIDATE_REPAIR = "generate_validate_repair"
+
+
+@dataclass(frozen=True)
+class ExecutionHooks:
+    """Grouped execution hooks for the public `connect()` API."""
+
+    execution_port: QueryExecutionPort | None = None
+    error_classifier: ErrorClassifierPort | None = None
+    repair_policy: RepairPolicyPort | None = None
+
+
+@dataclass(frozen=True)
+class SemanticHooks:
+    """Grouped semantic hooks for the public `connect()` API."""
+
+    semantic_resolver: SemanticResolverPort | None = None
+    semantic_validator: SemanticValidatorPort | None = None
+    semantic_context: SemanticContext | None = None

--- a/src/nlp2sql/ports/ai_provider.py
+++ b/src/nlp2sql/ports/ai_provider.py
@@ -23,7 +23,7 @@ class QueryContext:
     question: str
     database_type: str  # postgres, mysql, etc.
     schema_context: str
-    examples: List[Dict[str, str]]
+    examples: List[Dict[str, Any]]
     max_tokens: int = 4096
     temperature: float = 0.1
     metadata: Optional[Dict[str, Any]] = None

--- a/src/nlp2sql/ports/error_classifier.py
+++ b/src/nlp2sql/ports/error_classifier.py
@@ -1,0 +1,19 @@
+"""Error classifier port for execution failures."""
+
+from abc import ABC, abstractmethod
+
+from ..core.entities import DatabaseType, ExecutionErrorInfo
+
+
+class ErrorClassifierPort(ABC):
+    """Classify execution errors into repair-friendly categories."""
+
+    @abstractmethod
+    def classify(
+        self,
+        error_message: str,
+        database_type: DatabaseType,
+        sql: str,
+    ) -> ExecutionErrorInfo:
+        """Return a structured classification for the given execution error."""
+        pass

--- a/src/nlp2sql/ports/query_execution.py
+++ b/src/nlp2sql/ports/query_execution.py
@@ -1,0 +1,16 @@
+"""Query execution port for optional execution-time validation and repair."""
+
+from abc import ABC, abstractmethod
+
+
+class QueryExecutionPort(ABC):
+    """Execute generated SQL in read-only mode."""
+
+    @abstractmethod
+    async def execute_readonly(
+        self,
+        sql: str,
+        timeout_seconds: int = 30,
+    ) -> dict[str, object]:
+        """Execute a read-only SQL statement and return execution metadata."""
+        pass

--- a/src/nlp2sql/ports/repair_policy.py
+++ b/src/nlp2sql/ports/repair_policy.py
@@ -1,0 +1,19 @@
+"""Repair policy port for execution-aware query generation."""
+
+from abc import ABC, abstractmethod
+
+from ..core.entities import DatabaseType, ExecutionErrorInfo, RepairDecision
+
+
+class RepairPolicyPort(ABC):
+    """Decide whether a failed query should be repaired and retried."""
+
+    @abstractmethod
+    def decide(
+        self,
+        error: ExecutionErrorInfo,
+        database_type: DatabaseType,
+        attempt: int,
+    ) -> RepairDecision:
+        """Return the repair decision for a classified execution error."""
+        pass

--- a/src/nlp2sql/ports/semantic_resolver.py
+++ b/src/nlp2sql/ports/semantic_resolver.py
@@ -1,0 +1,22 @@
+"""Port for resolving business semantic context."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from ..core.entities import DatabaseType, RetrievalPlan, SemanticContext
+
+
+class SemanticResolverPort(ABC):
+    """Resolve business semantics for a question from any backing store."""
+
+    @abstractmethod
+    async def resolve(
+        self,
+        question: str,
+        retrieval_plan: RetrievalPlan,
+        database_type: DatabaseType,
+        semantic_context: SemanticContext | None = None,
+    ) -> SemanticContext:
+        """Return a semantic context for the current question."""
+        raise NotImplementedError

--- a/src/nlp2sql/ports/semantic_validator.py
+++ b/src/nlp2sql/ports/semantic_validator.py
@@ -1,0 +1,21 @@
+"""Port for validating SQL against business semantic rules."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from ..core.entities import SemanticContext, SemanticValidationResult, SqlIntentPlan
+
+
+class SemanticValidatorPort(ABC):
+    """Validate generated SQL against business semantics."""
+
+    @abstractmethod
+    async def validate(
+        self,
+        sql: str,
+        semantic_context: SemanticContext,
+        sql_intent_plan: SqlIntentPlan | None = None,
+    ) -> SemanticValidationResult:
+        """Return semantic validation results for a generated SQL statement."""
+        raise NotImplementedError

--- a/src/nlp2sql/schema/example_store.py
+++ b/src/nlp2sql/schema/example_store.py
@@ -1,10 +1,13 @@
 """Example store for managing and retrieving query examples using vector similarity."""
 
+from __future__ import annotations
+
 import hashlib
 import pickle
+import re
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 import faiss
 import numpy as np
@@ -30,8 +33,8 @@ class ExampleStore(ExampleRepositoryPort):
     def __init__(
         self,
         embedding_provider: EmbeddingProviderPort,
-        index_path: Optional[Path] = None,
-        database_url: Optional[str] = None,
+        index_path: Path | None = None,
+        database_url: str | None = None,
         schema_name: str = "public",
     ):
         """
@@ -120,7 +123,7 @@ class ExampleStore(ExampleRepositoryPort):
                 dimension=self.embedding_dim,
             )
 
-    async def add_examples(self, examples: List[Dict[str, Any]]) -> None:
+    async def add_examples(self, examples: list[dict[str, Any]]) -> None:
         """
         Add examples to the store.
 
@@ -129,19 +132,20 @@ class ExampleStore(ExampleRepositoryPort):
                 {"question": str, "sql": str, "database_type": str, "metadata": dict}
         """
         new_examples = []
-        questions = []
+        embedding_texts = []
 
         for example in examples:
             # Create unique key based on question and SQL
             example_key = self._create_example_key(example)
 
             if example_key not in self.example_to_id:
-                questions.append(example["question"])
-                new_examples.append(example)
+                enriched_example = self._enrich_example(example)
+                embedding_texts.append(self._create_example_embedding_text(enriched_example))
+                new_examples.append(enriched_example)
 
                 # Store mapping
                 self.id_to_example[self._next_id] = {
-                    "example": example,
+                    "example": enriched_example,
                     "key": example_key,
                     "indexed_at": datetime.now().isoformat(),
                 }
@@ -149,8 +153,8 @@ class ExampleStore(ExampleRepositoryPort):
                 self._next_id += 1
 
         if new_examples:
-            # Create embeddings for questions
-            embeddings = await self.embedding_provider.encode(questions)
+            # Create embeddings for rich example descriptions
+            embeddings = await self.embedding_provider.encode(embedding_texts)
 
             # Add to FAISS index
             self.index.add(np.array(embeddings, dtype=np.float32))
@@ -168,9 +172,9 @@ class ExampleStore(ExampleRepositoryPort):
         self,
         question: str,
         top_k: int = 5,
-        database_type: Optional[str] = None,
+        database_type: str | None = None,
         min_score: float = 0.3,
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         """
         Search for similar examples.
 
@@ -210,18 +214,53 @@ class ExampleStore(ExampleRepositoryPort):
             if score < min_score:
                 continue
 
-            results.append(example)
+            results.append({**example, "similarity_score": float(score)})
 
             if len(results) >= top_k:
                 break
 
         return results
 
-    def _create_example_key(self, example: Dict[str, Any]) -> str:
+    def _create_example_key(self, example: dict[str, Any]) -> str:
         """Create unique key for example."""
         # Use hash of question + SQL to avoid duplicates
         content = f"{example['question']}|{example['sql']}"
         return hashlib.md5(content.encode()).hexdigest()
+
+    def _enrich_example(self, example: dict[str, Any]) -> dict[str, Any]:
+        """Normalize metadata so downstream selectors can rely on it."""
+        metadata = dict(example.get("metadata", {}))
+        metadata.setdefault("tables", self._extract_sql_tables(example.get("sql", "")))
+        return {**example, "metadata": metadata}
+
+    def _create_example_embedding_text(self, example: dict[str, Any]) -> str:
+        """Create richer text used to index examples semantically."""
+        metadata = example.get("metadata", {})
+        tables = metadata.get("tables", [])
+        metrics = metadata.get("metrics", [])
+        dimensions = metadata.get("dimensions", [])
+        intent = metadata.get("intent")
+
+        parts = [f"Question: {example['question']}", f"SQL: {example['sql']}"]
+        if tables:
+            parts.append(f"Tables: {', '.join(tables)}")
+        if metrics:
+            parts.append(f"Metrics: {', '.join(metrics)}")
+        if dimensions:
+            parts.append(f"Dimensions: {', '.join(dimensions)}")
+        if intent:
+            parts.append(f"Intent: {intent}")
+
+        return " | ".join(parts)
+
+    def _extract_sql_tables(self, sql: str) -> list[str]:
+        matches = re.findall(r"\b(?:from|join)\s+([a-zA-Z0-9_.\"]+)", sql, flags=re.IGNORECASE)
+        tables: list[str] = []
+        for match in matches:
+            table_name = match.strip('"').split(".")[-1]
+            if table_name not in tables:
+                tables.append(table_name)
+        return tables
 
     async def _save_index(self) -> None:
         """Save FAISS index and metadata with provider tracking."""
@@ -261,7 +300,7 @@ class ExampleStore(ExampleRepositoryPort):
 
         logger.info("Cleared example store")
 
-    def get_stats(self) -> Dict[str, Any]:
+    def get_stats(self) -> dict[str, Any]:
         """Get statistics about the example store."""
         return {
             "total_examples": len(self.id_to_example),

--- a/src/nlp2sql/services/example_selection_service.py
+++ b/src/nlp2sql/services/example_selection_service.py
@@ -1,0 +1,188 @@
+"""Selection and reranking for few-shot examples."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+import re
+from typing import Any
+
+from ..core.entities import DatabaseType, ExampleCandidate, QueryIntent, RetrievalPlan, SemanticContext
+from ..ports.example_repository import ExampleRepositoryPort
+
+
+class ExampleSelectionService:
+    """Select examples using schema-aware reranking while preserving the existing port."""
+
+    def __init__(self, example_store: ExampleRepositoryPort | None, max_examples: int, max_prompt_examples: int):
+        self.example_store = example_store
+        self.max_examples = max_examples
+        self.max_prompt_examples = max_prompt_examples
+
+    async def select_examples(
+        self,
+        question: str,
+        database_type: DatabaseType,
+        retrieval_plan: RetrievalPlan,
+        relevant_tables: Sequence[tuple[str, float]],
+        semantic_context: SemanticContext | None = None,
+    ) -> list[dict[str, Any]]:
+        """Return reranked examples for prompting."""
+        if self.example_store is None:
+            return []
+
+        table_names = [table_name for table_name, _ in relevant_tables[:5]]
+        retrieval_query = " ".join([retrieval_plan.example_query, *table_names]).strip()
+
+        candidates = await self.example_store.search_similar(
+            question=retrieval_query,
+            top_k=max(self.max_examples * 3, self.max_examples + 2),
+            database_type=database_type.value,
+            min_score=0.2,
+        )
+
+        if not candidates:
+            return []
+
+        reranked = [
+            self._build_candidate(candidate, retrieval_plan, table_names, semantic_context)
+            for candidate in candidates
+        ]
+        reranked.sort(key=lambda candidate: candidate.score, reverse=True)
+
+        selected: list[dict[str, Any]] = []
+        seen_signatures: set[str] = set()
+        for candidate in reranked:
+            signature = self._build_diversity_signature(candidate)
+            if signature in seen_signatures and len(selected) >= self.max_prompt_examples:
+                continue
+
+            seen_signatures.add(signature)
+            selected.append(
+                {
+                    "question": candidate.question,
+                    "sql": candidate.sql,
+                    "metadata": {
+                        **candidate.metadata,
+                        "tables": candidate.tables,
+                        "intent": candidate.intent.value if candidate.intent else None,
+                        "rerank_score": round(candidate.score, 4),
+                    },
+                }
+            )
+            if len(selected) >= self.max_examples:
+                break
+
+        return selected
+
+    def _build_candidate(
+        self,
+        example: dict[str, Any],
+        retrieval_plan: RetrievalPlan,
+        relevant_tables: Sequence[str],
+        semantic_context: SemanticContext | None,
+    ) -> ExampleCandidate:
+        metadata = dict(example.get("metadata", {}))
+        similarity_score = float(example.get("similarity_score", 0.0))
+        tables = metadata.get("tables") or self._extract_sql_tables(example.get("sql", ""))
+        intent = self._resolve_intent(metadata, example)
+
+        table_overlap = 0.0
+        if relevant_tables and tables:
+            shared = len(set(tables) & set(relevant_tables))
+            table_overlap = shared / max(len(set(relevant_tables)), 1)
+
+        business_terms = set(retrieval_plan.intent_context.business_terms)
+        example_terms = set(self._tokenize(example.get("question", "")))
+        business_overlap = len(business_terms & example_terms) / max(len(business_terms), 1) if business_terms else 0.0
+
+        intent_match = 1.0 if intent == retrieval_plan.intent_context.intent else 0.0
+        canonical_table_bonus = 0.0
+        semantic_filter_bonus = 0.0
+        if semantic_context and not semantic_context.is_empty():
+            if set(tables) & set(semantic_context.canonical_tables):
+                canonical_table_bonus = 1.0
+            required_filters = {
+                filter_text.lower()
+                for filter_text in semantic_context.required_filters
+            }
+            mapping_filters = {
+                mapping.filter_expression.lower()
+                for mapping in semantic_context.entity_mappings
+                if mapping.filter_expression
+            }
+            sql_lower = example.get("sql", "").lower()
+            expected_filters = required_filters | mapping_filters
+            if expected_filters:
+                matched_filters = sum(1 for filter_text in expected_filters if filter_text in sql_lower)
+                semantic_filter_bonus = matched_filters / max(len(expected_filters), 1)
+
+        score = (
+            similarity_score * 0.45
+            + table_overlap * 0.25
+            + intent_match * 0.15
+            + business_overlap * 0.05
+            + canonical_table_bonus * 0.07
+            + semantic_filter_bonus * 0.03
+        )
+
+        metadata.setdefault("similarity_score", similarity_score)
+        metadata.setdefault("table_overlap", round(table_overlap, 4))
+        metadata.setdefault("intent_match", intent_match)
+        metadata.setdefault("canonical_table_bonus", canonical_table_bonus)
+        metadata.setdefault("semantic_filter_bonus", round(semantic_filter_bonus, 4))
+
+        return ExampleCandidate(
+            question=example.get("question", ""),
+            sql=example.get("sql", ""),
+            score=score,
+            tables=tables,
+            intent=intent,
+            metadata=metadata,
+        )
+
+    def _resolve_intent(self, metadata: dict[str, Any], example: dict[str, Any]) -> QueryIntent | None:
+        raw_intent = metadata.get("intent")
+        if isinstance(raw_intent, str):
+            for value in QueryIntent:
+                if raw_intent.lower() == value.value:
+                    return value
+        return self._infer_intent_from_text(" ".join([example.get("question", ""), example.get("sql", "")]))
+
+    def _infer_intent_from_text(self, text: str) -> QueryIntent:
+        lowered = text.lower()
+        if any(keyword in lowered for keyword in ("group by", "sum(", "count(", "avg(", "total")):
+            return QueryIntent.AGGREGATE
+        if any(keyword in lowered for keyword in ("join", " left ", " right ", " inner ")):
+            return QueryIntent.JOIN
+        if any(keyword in lowered for keyword in ("order by", "top", "limit")):
+            return QueryIntent.ORDER
+        if "where" in lowered:
+            return QueryIntent.FILTER
+        return QueryIntent.SELECT
+
+    def _extract_sql_tables(self, sql: str) -> list[str]:
+        matches = re.findall(r"\b(?:from|join)\s+([a-zA-Z0-9_.\"]+)", sql, flags=re.IGNORECASE)
+        tables = []
+        for match in matches:
+            table_name = match.strip('"')
+            table_name = table_name.split(".")[-1]
+            tables.append(table_name)
+        return self._unique_ordered(tables)
+
+    def _tokenize(self, text: str) -> list[str]:
+        return re.findall(r"[a-z0-9_]+", text.lower())
+
+    def _build_diversity_signature(self, candidate: ExampleCandidate) -> str:
+        table_part = ",".join(candidate.tables[:3]) if candidate.tables else "no-table"
+        intent_part = candidate.intent.value if candidate.intent else "unknown"
+        return f"{intent_part}:{table_part}"
+
+    def _unique_ordered(self, values: list[str]) -> list[str]:
+        seen: set[str] = set()
+        result: list[str] = []
+        for value in values:
+            if not value or value in seen:
+                continue
+            seen.add(value)
+            result.append(value)
+        return result

--- a/src/nlp2sql/services/prompt_assembly_service.py
+++ b/src/nlp2sql/services/prompt_assembly_service.py
@@ -1,0 +1,64 @@
+"""Prompt assembly helpers shared across query generation flows."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..core.entities import RetrievalPlan, SemanticContext, SqlIntentPlan
+from ..config.settings import settings
+from ..ports.ai_provider import QueryContext
+
+
+class PromptAssemblyService:
+    """Build the final QueryContext from retrieval outputs."""
+
+    def build_query_context(
+        self,
+        question: str,
+        database_type: str,
+        schema_context: str,
+        retrieval_plan: RetrievalPlan,
+        examples: list[dict[str, Any]],
+        semantic_context: SemanticContext | None,
+        sql_intent_plan: SqlIntentPlan | None,
+        max_tokens: int,
+        temperature: float,
+        metadata: dict[str, Any] | None = None,
+    ) -> QueryContext:
+        """Create a QueryContext with structured metadata for the provider."""
+        prompt_examples = examples[: settings.max_prompt_examples]
+        base_metadata: dict[str, object] = {
+            "intent_context": {
+                "intent": retrieval_plan.intent_context.intent.value,
+                "business_terms": retrieval_plan.intent_context.business_terms,
+                "metrics": retrieval_plan.intent_context.metrics,
+                "dimensions": retrieval_plan.intent_context.dimensions,
+                "time_grains": retrieval_plan.intent_context.time_grains,
+                "filters": retrieval_plan.intent_context.filters,
+                "expected_operations": retrieval_plan.intent_context.expected_operations,
+                "requires_aggregation": retrieval_plan.intent_context.requires_aggregation,
+                "requires_join": retrieval_plan.intent_context.requires_join,
+                "requires_ordering": retrieval_plan.intent_context.requires_ordering,
+            },
+            "retrieval_plan": {
+                "retrieval_query": retrieval_plan.retrieval_query,
+                "example_query": retrieval_plan.example_query,
+                "keyword_hints": retrieval_plan.keyword_hints,
+            },
+            "semantic_context": semantic_context.to_metadata() if semantic_context else {},
+            "sql_intent_plan": sql_intent_plan.to_metadata() if sql_intent_plan else {},
+            "retrieved_examples_count": len(examples),
+            "prompt_examples_count": len(prompt_examples),
+        }
+        if metadata:
+            base_metadata.update(metadata)
+
+        return QueryContext(
+            question=question,
+            database_type=database_type,
+            schema_context=schema_context,
+            examples=prompt_examples,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            metadata=base_metadata,
+        )

--- a/src/nlp2sql/services/query_analysis_service.py
+++ b/src/nlp2sql/services/query_analysis_service.py
@@ -1,0 +1,231 @@
+"""Heuristic query analysis shared across retrieval and prompting."""
+
+from __future__ import annotations
+
+import re
+
+from ..core.entities import QueryIntent, QueryIntentContext, RetrievalPlan
+
+_STOP_WORDS = {
+    "a",
+    "all",
+    "an",
+    "and",
+    "are",
+    "as",
+    "at",
+    "be",
+    "by",
+    "for",
+    "from",
+    "how",
+    "i",
+    "in",
+    "is",
+    "it",
+    "last",
+    "me",
+    "of",
+    "on",
+    "or",
+    "show",
+    "the",
+    "this",
+    "to",
+    "was",
+    "what",
+    "which",
+    "with",
+}
+
+_METRIC_KEYWORDS = {
+    "amount",
+    "avg",
+    "average",
+    "clicks",
+    "count",
+    "cost",
+    "cpa",
+    "cpc",
+    "cvr",
+    "margin",
+    "orders",
+    "profit",
+    "rate",
+    "revenue",
+    "roas",
+    "sales",
+    "sessions",
+    "spend",
+    "sum",
+    "total",
+    "users",
+}
+
+_DIMENSION_KEYWORDS = {
+    "campaign",
+    "campaigns",
+    "category",
+    "channel",
+    "country",
+    "date",
+    "day",
+    "layer",
+    "month",
+    "product",
+    "region",
+    "source",
+    "status",
+    "store",
+    "strategy",
+    "week",
+    "year",
+}
+
+_TIME_KEYWORDS = {
+    "daily",
+    "day",
+    "days",
+    "monthly",
+    "month",
+    "months",
+    "weekly",
+    "week",
+    "weeks",
+    "year",
+    "yearly",
+    "ytd",
+}
+
+
+class QueryAnalysisService:
+    """Analyze a natural-language question before retrieval and prompting."""
+
+    def analyze(self, question: str) -> RetrievalPlan:
+        """Create a retrieval plan from a natural-language question."""
+        normalized_question = self._normalize_question(question)
+        tokens = self._tokenize(normalized_question)
+        filtered_tokens = [token for token in tokens if token not in _STOP_WORDS]
+
+        intent_context = QueryIntentContext(
+            intent=self._infer_intent(normalized_question),
+            business_terms=filtered_tokens[:12],
+            metrics=self._extract_keywords(filtered_tokens, _METRIC_KEYWORDS),
+            dimensions=self._extract_keywords(filtered_tokens, _DIMENSION_KEYWORDS),
+            time_grains=self._extract_keywords(filtered_tokens, _TIME_KEYWORDS),
+            filters=self._extract_filters(normalized_question),
+            expected_operations=self._extract_expected_operations(normalized_question),
+            requires_aggregation=self._requires_aggregation(normalized_question),
+            requires_join=self._requires_join(normalized_question),
+            requires_ordering=self._requires_ordering(normalized_question),
+            metadata={"token_count": len(filtered_tokens)},
+        )
+
+        retrieval_terms = self._unique_ordered(
+            [
+                *intent_context.metrics,
+                *intent_context.dimensions,
+                *intent_context.time_grains,
+                *intent_context.business_terms,
+            ]
+        )
+        retrieval_query = " ".join([question.strip(), *retrieval_terms]).strip()
+
+        example_terms = self._unique_ordered(
+            [
+                intent_context.intent.value,
+                *intent_context.expected_operations,
+                *intent_context.metrics,
+                *intent_context.dimensions,
+                *intent_context.time_grains,
+                *intent_context.filters,
+                *intent_context.business_terms[:8],
+            ]
+        )
+        example_query = " ".join([question.strip(), *example_terms]).strip()
+
+        return RetrievalPlan(
+            original_question=question,
+            normalized_question=normalized_question,
+            intent_context=intent_context,
+            retrieval_query=retrieval_query,
+            example_query=example_query,
+            keyword_hints=retrieval_terms[:10],
+            metadata={
+                "business_terms": intent_context.business_terms,
+                "metrics": intent_context.metrics,
+                "dimensions": intent_context.dimensions,
+                "time_grains": intent_context.time_grains,
+            },
+        )
+
+    def _normalize_question(self, question: str) -> str:
+        return re.sub(r"\s+", " ", question.strip().lower())
+
+    def _tokenize(self, question: str) -> list[str]:
+        return re.findall(r"[a-z0-9_]+", question)
+
+    def _infer_intent(self, question: str) -> QueryIntent:
+        if any(keyword in question for keyword in ("compare", "versus", "vs")):
+            return QueryIntent.COMPLEX
+        if any(keyword in question for keyword in ("top", "highest", "lowest", "best", "worst")):
+            return QueryIntent.ORDER
+        if any(keyword in question for keyword in ("break down", "group by", "per ", "by ")) and any(
+            keyword in question for keyword in ("sum", "count", "avg", "average", "total", "revenue", "spend")
+        ):
+            return QueryIntent.GROUP
+        if any(keyword in question for keyword in ("sum", "count", "avg", "average", "total")):
+            return QueryIntent.AGGREGATE
+        if "join" in question or "across" in question:
+            return QueryIntent.JOIN
+        if any(keyword in question for keyword in ("where", "filter", "only", "last", "between")):
+            return QueryIntent.FILTER
+        return QueryIntent.SELECT
+
+    def _extract_keywords(self, tokens: list[str], candidates: set[str]) -> list[str]:
+        return [token for token in tokens if token in candidates]
+
+    def _extract_filters(self, question: str) -> list[str]:
+        filters = []
+        if "last " in question:
+            filters.append("relative_time_window")
+        if "between " in question:
+            filters.append("between_clause")
+        if "top " in question:
+            filters.append("limit_ranking")
+        if " by " in question:
+            filters.append("grouping_dimension")
+        return filters
+
+    def _extract_expected_operations(self, question: str) -> list[str]:
+        operations: list[str] = []
+        if self._requires_aggregation(question):
+            operations.append("aggregation")
+        if self._requires_join(question):
+            operations.append("join")
+        if self._requires_ordering(question):
+            operations.append("order_by")
+        if "distinct" in question:
+            operations.append("distinct")
+        if any(keyword in question for keyword in ("trend", "daily", "weekly", "monthly")):
+            operations.append("time_series")
+        return operations
+
+    def _requires_aggregation(self, question: str) -> bool:
+        return any(keyword in question for keyword in ("sum", "count", "avg", "average", "total", "trend", "rate"))
+
+    def _requires_join(self, question: str) -> bool:
+        return any(keyword in question for keyword in (" by ", "across", "per ", "compare", "with "))
+
+    def _requires_ordering(self, question: str) -> bool:
+        return any(keyword in question for keyword in ("top", "highest", "lowest", "best", "worst", "rank"))
+
+    def _unique_ordered(self, values: list[str]) -> list[str]:
+        seen: set[str] = set()
+        result: list[str] = []
+        for value in values:
+            if not value or value in seen:
+                continue
+            seen.add(value)
+            result.append(value)
+        return result

--- a/src/nlp2sql/services/query_repair_service.py
+++ b/src/nlp2sql/services/query_repair_service.py
@@ -1,0 +1,62 @@
+"""Execution-aware query repair helpers."""
+
+from __future__ import annotations
+
+from ..core.entities import DatabaseType, RepairContext
+from ..ports.ai_provider import AIProviderPort, QueryContext, QueryResponse
+
+
+class QueryRepairService:
+    """Regenerate SQL using structured execution feedback."""
+
+    def __init__(self, ai_provider: AIProviderPort):
+        self.ai_provider = ai_provider
+
+    async def repair(
+        self,
+        question: str,
+        database_type: DatabaseType,
+        schema_context: str,
+        examples: list[dict[str, object]],
+        repair_context: RepairContext,
+        max_tokens: int,
+        temperature: float,
+        metadata: dict[str, object],
+    ) -> QueryResponse:
+        """Generate a corrected query informed by the previous execution failure."""
+        retry_prompt = self._build_retry_question(question, repair_context)
+        retry_context = QueryContext(
+            question=retry_prompt,
+            database_type=database_type.value,
+            schema_context=schema_context,
+            examples=examples,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            metadata={**metadata, "repair_context": self._serialize_repair_context(repair_context)},
+        )
+        return await self.ai_provider.generate_query(retry_context)
+
+    def _build_retry_question(self, question: str, repair_context: RepairContext) -> str:
+        hints = "\n".join(f"- {hint}" for hint in repair_context.error.hints)
+        hint_block = f"\nExecution Hints:\n{hints}\n" if hints else ""
+        return (
+            f"{question}\n\n"
+            f"PREVIOUS SQL:\n{repair_context.previous_sql}\n\n"
+            f"EXECUTION ERROR CATEGORY: {repair_context.error.category}\n"
+            f"EXECUTION ERROR MESSAGE: {repair_context.error.message}\n"
+            f"{hint_block}"
+            "Regenerate the SQL so it answers the original question, keeps read-only semantics, "
+            "uses only the available schema, and avoids the previous execution error."
+        )
+
+    def _serialize_repair_context(self, repair_context: RepairContext) -> dict[str, object]:
+        return {
+            "attempt": repair_context.attempt,
+            "previous_sql": repair_context.previous_sql,
+            "error": {
+                "category": repair_context.error.category,
+                "message": repair_context.error.message,
+                "retryable": repair_context.error.retryable,
+                "hints": repair_context.error.hints,
+            },
+        }

--- a/src/nlp2sql/services/query_service.py
+++ b/src/nlp2sql/services/query_service.py
@@ -1,21 +1,45 @@
 """Main service for natural language to SQL conversion."""
 
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import asdict
+import hashlib
+import json
+import re
 from datetime import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 import structlog
 
 from ..config.settings import settings
-from ..core.entities import DatabaseType
+from ..core.entities import (
+    DatabaseType,
+    RepairContext,
+    SemanticContext,
+    SqlIntentPlan,
+)
 from ..exceptions import QueryGenerationException, ValidationException
-from ..ports.ai_provider import AIProviderPort, QueryContext
+from ..ports.ai_provider import AIProviderPort, QueryContext, QueryResponse
 from ..ports.cache import CachePort
 from ..ports.embedding_provider import EmbeddingProviderPort
+from ..ports.error_classifier import ErrorClassifierPort
 from ..ports.example_repository import ExampleRepositoryPort
+from ..ports.query_execution import QueryExecutionPort
 from ..ports.query_optimizer import QueryOptimizerPort
 from ..ports.query_validator import QueryValidatorPort
+from ..ports.repair_policy import RepairPolicyPort
 from ..ports.schema_repository import SchemaRepositoryPort
+from ..ports.semantic_resolver import SemanticResolverPort
+from ..ports.semantic_validator import SemanticValidatorPort
 from ..schema.manager import SchemaManager
+from .example_selection_service import ExampleSelectionService
+from .prompt_assembly_service import PromptAssemblyService
+from .query_analysis_service import QueryAnalysisService
+from .query_repair_service import QueryRepairService
+from .semantic_resolution_service import SemanticResolutionService
+from .semantic_validation_service import SemanticValidationService
+from .sql_intent_planning_service import SqlIntentPlanningService
 
 logger = structlog.get_logger()
 
@@ -27,13 +51,18 @@ class QueryGenerationService:
         self,
         ai_provider: AIProviderPort,
         schema_repository: SchemaRepositoryPort,
-        cache: Optional[CachePort] = None,
-        query_optimizer: Optional[QueryOptimizerPort] = None,
-        schema_filters: Optional[Dict[str, Any]] = None,
-        embedding_provider: Optional[EmbeddingProviderPort] = None,
-        example_store: Optional[ExampleRepositoryPort] = None,
-        query_validator: Optional[QueryValidatorPort] = None,
+        cache: CachePort | None = None,
+        query_optimizer: QueryOptimizerPort | None = None,
+        schema_filters: dict[str, Any] | None = None,
+        embedding_provider: EmbeddingProviderPort | None = None,
+        example_store: ExampleRepositoryPort | None = None,
+        query_validator: QueryValidatorPort | None = None,
         schema_name: str = "public",
+        execution_port: QueryExecutionPort | None = None,
+        error_classifier: ErrorClassifierPort | None = None,
+        repair_policy: RepairPolicyPort | None = None,
+        semantic_resolver: SemanticResolverPort | None = None,
+        semantic_validator: SemanticValidatorPort | None = None,
     ):
         self.ai_provider = ai_provider
         self.schema_repository = schema_repository
@@ -41,8 +70,10 @@ class QueryGenerationService:
         self.query_optimizer = query_optimizer
         self.query_validator = query_validator
         self.schema_name = schema_name
+        self.execution_port = execution_port
+        self.error_classifier = error_classifier
+        self.repair_policy = repair_policy
 
-        # Initialize schema manager with embedding provider
         self.schema_manager = SchemaManager(
             repository=schema_repository,
             cache=cache,
@@ -50,25 +81,29 @@ class QueryGenerationService:
             schema_filters=schema_filters,
             schema_name=schema_name,
         )
-
-        # Initialize example store
         self.example_store = example_store
-
-        # Configuration — centralized in settings, overridable per instance
-        from ..config.settings import settings
-
         self.max_examples = settings.max_examples
         self.cache_ttl_hours = settings.schema_refresh_interval_hours
         self.enable_query_optimization = True
 
+        self.query_analysis_service = QueryAnalysisService()
+        self.example_selection_service = ExampleSelectionService(
+            example_store=example_store,
+            max_examples=settings.max_examples,
+            max_prompt_examples=settings.max_prompt_examples,
+        )
+        self.prompt_assembly_service = PromptAssemblyService()
+        self.query_repair_service = QueryRepairService(ai_provider=ai_provider)
+        self.semantic_resolution_service = SemanticResolutionService(semantic_resolver=semantic_resolver)
+        self.sql_intent_planning_service = SqlIntentPlanningService()
+        self.semantic_validation_service = SemanticValidationService(semantic_validator=semantic_validator)
+
     async def initialize(self, database_type: DatabaseType) -> None:
         """Initialize the service."""
         try:
-            # Initialize schema repository first
             if hasattr(self.schema_repository, "initialize"):
                 await self.schema_repository.initialize()
 
-            # Initialize schema manager
             await self.schema_manager.initialize(database_type)
 
             logger.info(
@@ -79,82 +114,110 @@ class QueryGenerationService:
 
         except Exception as e:
             logger.error("Failed to initialize query service", error=str(e))
-            raise QueryGenerationException(f"Service initialization failed: {e!s}")
+            raise QueryGenerationException(f"Service initialization failed: {e!s}") from e
 
     async def generate_sql(
         self,
         question: str,
         database_type: DatabaseType,
-        max_tokens: Optional[int] = None,
-        temperature: Optional[float] = None,
+        max_tokens: int | None = None,
+        temperature: float | None = None,
         include_explanation: bool = True,
-    ) -> Dict[str, Any]:
+        execution_mode: str = "generate_only",
+        timeout_seconds: int = 30,
+        semantic_context: SemanticContext | None = None,
+    ) -> dict[str, Any]:
         """Generate SQL query from natural language question."""
         try:
             start_time = datetime.now()
+            resolved_max_tokens = max_tokens or settings.default_max_tokens
+            resolved_temperature = temperature if temperature is not None else settings.default_temperature
 
-            # Check cache first
-            cache_key = f"query:{question}:{database_type.value}:{self.ai_provider.provider_type.value}"
-            if self.cache:
+            retrieval_plan = self.query_analysis_service.analyze(question)
+            semantic_context, retrieval_plan = await self.semantic_resolution_service.resolve(
+                question=question,
+                retrieval_plan=retrieval_plan,
+                database_type=database_type,
+                semantic_context=semantic_context,
+            )
+
+            semantic_signature = self._semantic_signature(semantic_context)
+            cache_key = (
+                f"query:{question}:{database_type.value}:{self.ai_provider.provider_type.value}:"
+                f"{execution_mode}:{resolved_max_tokens}:{resolved_temperature}:{semantic_signature}"
+            )
+            if (
+                self.cache
+                and execution_mode == "generate_only"
+                and not self.semantic_resolution_service.is_configured
+            ):
                 cached_result = await self.cache.get(cache_key)
                 if cached_result:
                     logger.info("Query served from cache", question=question[:50])
                     return cached_result
 
-            # Get optimal schema context
+            relevant_tables = await self.schema_manager.find_relevant_tables(
+                retrieval_plan.retrieval_query,
+                database_type,
+                self.max_examples * 2,
+            )
             schema_context = await self.schema_manager.get_optimal_schema_context(
-                question, database_type, max_tokens or settings.max_schema_tokens
+                retrieval_plan.retrieval_query,
+                database_type,
+                max_tokens or settings.max_schema_tokens,
+            )
+            examples = await self._find_relevant_examples(
+                question,
+                database_type,
+                retrieval_plan,
+                relevant_tables,
+                semantic_context,
+            )
+            sql_intent_plan = self.sql_intent_planning_service.build(
+                retrieval_plan=retrieval_plan,
+                semantic_context=semantic_context,
+                relevant_tables=list(relevant_tables),
+                examples=examples,
             )
 
-            # Find relevant examples
-            examples = await self._find_relevant_examples(question, database_type)
-
-            # Create query context
-            query_context = QueryContext(
+            query_context = self.prompt_assembly_service.build_query_context(
                 question=question,
                 database_type=database_type.value,
                 schema_context=schema_context,
+                retrieval_plan=retrieval_plan,
                 examples=examples,
-                max_tokens=max_tokens or settings.default_max_tokens,
-                temperature=temperature or settings.default_temperature,
-                metadata={"service_version": "1.0", "timestamp": start_time.isoformat()},
+                semantic_context=semantic_context,
+                sql_intent_plan=sql_intent_plan,
+                max_tokens=resolved_max_tokens,
+                temperature=resolved_temperature,
+                metadata={
+                    "service_version": "1.1",
+                    "timestamp": start_time.isoformat(),
+                    "relevant_tables": [table_name for table_name, _ in relevant_tables],
+                },
             )
 
-            # Generate SQL
-            response = await self.ai_provider.generate_query(query_context)
+            response, validation_result, execution_validation, repair_attempts = await self._generate_response_pipeline(
+                query_context=query_context,
+                database_type=database_type,
+                execution_mode=execution_mode,
+                timeout_seconds=timeout_seconds,
+                semantic_context=semantic_context,
+                sql_intent_plan=sql_intent_plan,
+            )
 
-            # Validate column names against schema and retry once if needed
-            column_errors = await self._validate_column_names(response.sql)
-            if column_errors and not (query_context.metadata or {}).get("_is_retry"):
-                logger.info("Column validation failed, retrying", errors=column_errors)
-                retry_context = QueryContext(
-                    question=(
-                        f"{query_context.question}\n\n"
-                        f"COLUMN ERRORS in previous attempt: {'; '.join(column_errors)}\n"
-                        f"Fix the SQL using ONLY exact column names from the schema."
-                    ),
-                    database_type=query_context.database_type,
-                    schema_context=schema_context,
-                    examples=query_context.examples,
-                    max_tokens=query_context.max_tokens,
-                    temperature=0.0,
-                    metadata={**(query_context.metadata or {}), "_is_retry": True},
-                )
-                response = await self.ai_provider.generate_query(retry_context)
+            result_metadata = {
+                **(response.metadata or {}),
+                "intent_context": (query_context.metadata or {}).get("intent_context", {}),
+                "retrieval_plan": (query_context.metadata or {}).get("retrieval_plan", {}),
+                "semantic_context": (query_context.metadata or {}).get("semantic_context", {}),
+                "sql_intent_plan": (query_context.metadata or {}).get("sql_intent_plan", {}),
+                "relevant_tables": (query_context.metadata or {}).get("relevant_tables", []),
+                "selected_examples": [example.get("metadata", {}) for example in query_context.examples],
+                "repair_attempts": repair_attempts,
+                "execution_validation": execution_validation,
+            }
 
-            # Optimize query if enabled
-            if self.enable_query_optimization and self.query_optimizer:
-                optimization_result = await self.query_optimizer.optimize(response.sql)
-                response.sql = optimization_result.optimized_query
-                response.metadata["optimization"] = {
-                    "applied": optimization_result.optimizations_applied,
-                    "improvement": optimization_result.estimated_improvement,
-                }
-
-            # Validate query
-            validation_result = await self.ai_provider.validate_query(response.sql, schema_context)
-
-            # Build result
             result = {
                 "sql": response.sql,
                 "explanation": response.explanation if include_explanation else None,
@@ -165,12 +228,16 @@ class QueryGenerationService:
                 "generation_time_ms": (datetime.now() - start_time).total_seconds() * 1000,
                 "validation": validation_result,
                 "schema_context_length": len(schema_context),
-                "examples_used": len(examples),
-                "metadata": response.metadata,
+                "examples_used": len(query_context.examples),
+                "metadata": result_metadata,
             }
 
-            # Cache result
-            if self.cache and validation_result.get("is_valid", False):
+            if (
+                self.cache
+                and execution_mode == "generate_only"
+                and validation_result.get("is_valid", False)
+                and not self.semantic_resolution_service.is_configured
+            ):
                 await self.cache.set(cache_key, result)
 
             logger.info(
@@ -179,6 +246,7 @@ class QueryGenerationService:
                 confidence=response.confidence,
                 tokens_used=response.tokens_used,
                 valid=validation_result.get("is_valid", False),
+                execution_mode=execution_mode,
             )
 
             return result
@@ -192,18 +260,16 @@ class QueryGenerationService:
             )
             raise QueryGenerationException(f"SQL generation failed: {e!s}") from e
 
-    async def validate_sql(self, sql: str, database_type: DatabaseType) -> Dict[str, Any]:
+    async def validate_sql(self, sql: str, database_type: DatabaseType) -> dict[str, Any]:
         """Validate SQL query."""
         try:
-            # Get schema context for validation
             schema_context = await self.schema_manager.get_optimal_schema_context(
                 sql, database_type, settings.max_schema_tokens
             )
-
-            # Validate with AI provider
             validation_result = await self.ai_provider.validate_query(sql, schema_context)
+            validation_result["column_errors"] = await self._validate_column_names(sql)
+            validation_result["dialect_issues"] = self._validate_dialect_rules(sql, database_type)
 
-            # Additional validation with query optimizer if available
             if self.query_optimizer:
                 analysis = await self.query_optimizer.analyze(sql)
                 validation_result["analysis"] = {
@@ -216,24 +282,20 @@ class QueryGenerationService:
 
         except Exception as e:
             logger.error("SQL validation failed", sql=sql[:100], error=str(e))
-            raise ValidationException(f"SQL validation failed: {e!s}")
+            raise ValidationException(f"SQL validation failed: {e!s}") from e
 
     async def get_query_suggestions(
         self, partial_question: str, database_type: DatabaseType, max_suggestions: int = 5
-    ) -> List[Dict[str, Any]]:
+    ) -> list[dict[str, Any]]:
         """Get query suggestions based on partial input."""
         try:
-            # Find relevant tables
             relevant_tables = await self.schema_manager.find_relevant_tables(
                 partial_question, database_type, max_suggestions * 2
             )
 
-            # Generate suggestions based on tables
             suggestions = []
             for table_name, relevance in relevant_tables:
                 table_info = await self.schema_repository.get_table_info(table_name)
-
-                # Create basic suggestions
                 suggestions.append(
                     {
                         "type": "table_exploration",
@@ -244,8 +306,7 @@ class QueryGenerationService:
                     }
                 )
 
-                # Add column-specific suggestions
-                for column in table_info.columns[:3]:  # Top 3 columns
+                for column in table_info.columns[:3]:
                     if any(keyword in column["name"].lower() for keyword in ["name", "title", "description"]):
                         suggestions.append(
                             {
@@ -258,23 +319,19 @@ class QueryGenerationService:
                             }
                         )
 
-            # Sort by relevance and limit
-            suggestions.sort(key=lambda x: x["relevance"], reverse=True)
+            suggestions.sort(key=lambda item: item["relevance"], reverse=True)
             return suggestions[:max_suggestions]
 
         except Exception as e:
             logger.error("Failed to get query suggestions", partial_question=partial_question, error=str(e))
             return []
 
-    async def explain_query(self, sql: str, database_type: DatabaseType) -> Dict[str, Any]:
+    async def explain_query(self, sql: str, database_type: DatabaseType) -> dict[str, Any]:
         """Explain what an SQL query does."""
         try:
-            # Get schema context
             schema_context = await self.schema_manager.get_optimal_schema_context(
                 sql, database_type, settings.max_schema_tokens
             )
-
-            # Use AI provider to explain
             explanation_context = QueryContext(
                 question=f"Explain this SQL query: {sql}",
                 database_type=database_type.value,
@@ -285,9 +342,7 @@ class QueryGenerationService:
             )
 
             response = await self.ai_provider.generate_query(explanation_context)
-
-            # Analyze query structure
-            analysis = {}
+            analysis: dict[str, Any] = {}
             if self.query_optimizer:
                 analysis = await self.query_optimizer.analyze(sql)
 
@@ -300,32 +355,220 @@ class QueryGenerationService:
 
         except Exception as e:
             logger.error("Failed to explain query", sql=sql[:100], error=str(e))
-            raise QueryGenerationException(f"Query explanation failed: {e!s}")
+            raise QueryGenerationException(f"Query explanation failed: {e!s}") from e
 
-    async def _find_relevant_examples(self, question: str, database_type: DatabaseType) -> List[Dict[str, str]]:
-        """Find relevant example queries using vector similarity."""
-        # Use ExampleRepositoryPort if available; otherwise return empty list.
-        # Users control their own examples — no hardcoded fallbacks.
+    async def _generate_response_pipeline(
+        self,
+        query_context: QueryContext,
+        database_type: DatabaseType,
+        execution_mode: str,
+        timeout_seconds: int,
+        semantic_context: SemanticContext | None = None,
+        sql_intent_plan: SqlIntentPlan | None = None,
+    ) -> tuple[QueryResponse, dict[str, Any], dict[str, Any], list[dict[str, Any]]]:
+        response = await self.ai_provider.generate_query(query_context)
+        repair_attempts: list[dict[str, Any]] = []
+
+        while True:
+            validation_result = await self._validate_generated_sql(
+                response.sql,
+                query_context.schema_context,
+                database_type,
+                semantic_context=semantic_context,
+                sql_intent_plan=sql_intent_plan,
+            )
+            execution_validation = {"enabled": execution_mode != "generate_only", "success": None}
+
+            if validation_result["column_errors"] and not (query_context.metadata or {}).get("_column_retry"):
+                logger.info("Column validation failed, retrying", errors=validation_result["column_errors"])
+                query_context = self._build_column_retry_context(query_context, validation_result["column_errors"])
+                response = await self.ai_provider.generate_query(query_context)
+                repair_attempts.append(
+                    {"type": "column_retry", "errors": validation_result["column_errors"], "attempt": len(repair_attempts) + 1}
+                )
+                continue
+
+            semantic_validation = validation_result.get("semantic_validation", {})
+            semantic_issues = semantic_validation.get("issues", [])
+            if (
+                semantic_issues
+                and execution_mode == "generate_validate_repair"
+                and not (query_context.metadata or {}).get("_semantic_retry")
+            ):
+                issue_messages = [issue["message"] for issue in semantic_issues if issue.get("severity", "error") == "error"]
+                if issue_messages:
+                    logger.info("Semantic validation failed, retrying", issues=issue_messages)
+                    query_context = self._build_semantic_retry_context(query_context, issue_messages)
+                    response = await self.ai_provider.generate_query(query_context)
+                    repair_attempts.append(
+                        {
+                            "type": "semantic_retry",
+                            "issues": issue_messages,
+                            "attempt": len(repair_attempts) + 1,
+                        }
+                    )
+                    continue
+
+            if self.enable_query_optimization and self.query_optimizer:
+                optimization_result = await self.query_optimizer.optimize(response.sql)
+                response.sql = optimization_result.optimized_query
+                response.metadata = response.metadata or {}
+                response.metadata["optimization"] = {
+                    "applied": optimization_result.optimizations_applied,
+                    "improvement": optimization_result.estimated_improvement,
+                }
+
+            if execution_mode == "generate_only" or self.execution_port is None:
+                return response, validation_result, execution_validation, repair_attempts
+
+            execution_validation = await self._execute_or_repair(
+                response=response,
+                query_context=query_context,
+                database_type=database_type,
+                execution_mode=execution_mode,
+                timeout_seconds=timeout_seconds,
+                repair_attempts=repair_attempts,
+            )
+            if execution_validation.get("success", False):
+                return response, validation_result, execution_validation, repair_attempts
+
+            if execution_mode != "generate_validate_repair":
+                return response, validation_result, execution_validation, repair_attempts
+
+            if not execution_validation.get("repaired_response"):
+                return response, validation_result, execution_validation, repair_attempts
+
+            response = execution_validation["repaired_response"]
+
+    async def _execute_or_repair(
+        self,
+        response: QueryResponse,
+        query_context: QueryContext,
+        database_type: DatabaseType,
+        execution_mode: str,
+        timeout_seconds: int,
+        repair_attempts: list[dict[str, Any]],
+    ) -> dict[str, Any]:
+        try:
+            result = await self.execution_port.execute_readonly(response.sql, timeout_seconds=timeout_seconds)
+            return {
+                "enabled": True,
+                "success": True,
+                "result": {
+                    "row_count": result.get("row_count"),
+                    "execution_time_ms": result.get("execution_time_ms"),
+                },
+            }
+        except Exception as exc:
+            if execution_mode != "generate_validate_repair" or not self.error_classifier or not self.repair_policy:
+                return {"enabled": True, "success": False, "error": str(exc)}
+
+            error_info = self.error_classifier.classify(str(exc), database_type, response.sql)
+            decision = self.repair_policy.decide(error_info, database_type, len(repair_attempts))
+            if not decision.should_retry:
+                return {
+                    "enabled": True,
+                    "success": False,
+                    "error": error_info.message,
+                    "error_category": error_info.category,
+                    "decision": decision.reason,
+                }
+
+            repair_context = RepairContext(
+                original_question=query_context.question,
+                database_type=database_type,
+                previous_sql=response.sql,
+                error=error_info,
+                attempt=len(repair_attempts) + 1,
+                schema_context=query_context.schema_context,
+                examples=query_context.examples,
+                metadata=query_context.metadata or {},
+            )
+            repaired_response = await self.query_repair_service.repair(
+                question=query_context.question,
+                database_type=database_type,
+                schema_context=query_context.schema_context,
+                examples=query_context.examples,
+                repair_context=repair_context,
+                max_tokens=query_context.max_tokens,
+                temperature=0.0,
+                metadata=query_context.metadata or {},
+            )
+            repair_attempts.append(
+                {
+                    "type": "execution_repair",
+                    "attempt": repair_context.attempt,
+                    "error_category": error_info.category,
+                    "error": error_info.message,
+                }
+            )
+            return {
+                "enabled": True,
+                "success": False,
+                "error": error_info.message,
+                "error_category": error_info.category,
+                "decision": decision.reason,
+                "repaired_response": repaired_response,
+            }
+
+    async def _validate_generated_sql(
+        self,
+        sql: str,
+        schema_context: str,
+        database_type: DatabaseType,
+        semantic_context: SemanticContext | None = None,
+        sql_intent_plan: SqlIntentPlan | None = None,
+    ) -> dict[str, Any]:
+        validation_result = await self.ai_provider.validate_query(sql, schema_context)
+        column_errors = await self._validate_column_names(sql)
+        dialect_issues = self._validate_dialect_rules(sql, database_type)
+        semantic_validation = await self.semantic_validation_service.validate(sql, semantic_context, sql_intent_plan)
+
+        issues_key = "errors" if "errors" in validation_result else "issues"
+        validation_result.setdefault(issues_key, [])
+        validation_result.setdefault("warnings", [])
+        validation_result["column_errors"] = column_errors
+        validation_result["dialect_issues"] = dialect_issues
+        validation_result["semantic_validation"] = semantic_validation.to_metadata()
+
+        if column_errors:
+            validation_result[issues_key].extend(column_errors)
+            validation_result["is_valid"] = False
+        if dialect_issues:
+            validation_result["warnings"].extend(dialect_issues)
+        if semantic_validation.issues:
+            validation_result[issues_key].extend(issue.message for issue in semantic_validation.issues)
+            validation_result["is_valid"] = False
+        if semantic_validation.warnings:
+            validation_result["warnings"].extend(semantic_validation.warnings)
+
+        return validation_result
+
+    async def _find_relevant_examples(
+        self,
+        question: str,
+        database_type: DatabaseType,
+        retrieval_plan: Any,
+        relevant_tables: Sequence[tuple[str, float]],
+        semantic_context: SemanticContext | None = None,
+    ) -> list[dict[str, Any]]:
         if not self.example_store:
             return []
 
         try:
-            examples = await self.example_store.search_similar(
+            return await self.example_selection_service.select_examples(
                 question=question,
-                top_k=self.max_examples,
-                database_type=database_type.value,
-                min_score=0.3,
+                database_type=database_type,
+                retrieval_plan=retrieval_plan,
+                relevant_tables=relevant_tables,
+                semantic_context=semantic_context,
             )
-            return [{"question": ex["question"], "sql": ex["sql"]} for ex in examples]
         except Exception as e:
             logger.warning("Failed to retrieve examples from store", error=str(e))
             return []
 
-    async def _validate_column_names(self, sql: str) -> List[str]:
-        """Validate column names in SQL against the columns of referenced tables.
-
-        Delegates to the QueryValidatorPort if available.
-        """
+    async def _validate_column_names(self, sql: str) -> list[str]:
+        """Validate column names in SQL against the columns of referenced tables."""
         if not self.query_validator:
             return []
 
@@ -336,17 +579,73 @@ class QueryGenerationService:
 
         return await self.query_validator.validate_columns(sql, tables)
 
-    async def get_service_stats(self) -> Dict[str, Any]:
+    def _validate_dialect_rules(self, sql: str, database_type: DatabaseType) -> list[str]:
+        """Detect a few high-signal dialect mismatches before execution."""
+        if database_type != DatabaseType.REDSHIFT:
+            return []
+
+        rules = [
+            (r"\bTRUNC\s*\(", "Redshift requires DATE_TRUNC instead of TRUNC(date, format)."),
+            (r"\bDISTINCT\s+ON\b", "Redshift does not support DISTINCT ON; use ROW_NUMBER with QUALIFY/CTE."),
+            (r"\bSTRING_AGG\s*\(", "Redshift uses LISTAGG instead of STRING_AGG."),
+            (r"\bgenerate_series\s*\(", "Redshift does not support generate_series()."),
+            (r"\bARRAY_AGG\s*\(", "Redshift does not support ARRAY_AGG."),
+            (r"\bNOW\s*\(", "Prefer GETDATE() or CURRENT_DATE in Redshift."),
+            (r"\bINTERVAL\s+'", "Prefer DATEADD() instead of INTERVAL arithmetic in Redshift."),
+        ]
+        issues = []
+        for pattern, message in rules:
+            if re.search(pattern, sql, flags=re.IGNORECASE):
+                issues.append(message)
+        return issues
+
+    def _build_column_retry_context(self, query_context: QueryContext, column_errors: list[str]) -> QueryContext:
+        return QueryContext(
+            question=(
+                f"{query_context.question}\n\n"
+                f"COLUMN ERRORS in previous attempt: {'; '.join(column_errors)}\n"
+                "Fix the SQL using ONLY exact column names from the schema."
+            ),
+            database_type=query_context.database_type,
+            schema_context=query_context.schema_context,
+            examples=query_context.examples,
+            max_tokens=query_context.max_tokens,
+            temperature=0.0,
+            metadata={**(query_context.metadata or {}), "_column_retry": True},
+        )
+
+    def _build_semantic_retry_context(self, query_context: QueryContext, semantic_issues: list[str]) -> QueryContext:
+        return QueryContext(
+            question=(
+                f"{query_context.question}\n\n"
+                f"SEMANTIC ISSUES in previous attempt: {'; '.join(semantic_issues)}\n"
+                "Regenerate the SQL using the business context, required filters, preferred tables, and avoid rules."
+            ),
+            database_type=query_context.database_type,
+            schema_context=query_context.schema_context,
+            examples=query_context.examples,
+            max_tokens=query_context.max_tokens,
+            temperature=0.0,
+            metadata={**(query_context.metadata or {}), "_semantic_retry": True},
+        )
+
+    def _semantic_signature(self, semantic_context: SemanticContext | None) -> str:
+        if semantic_context is None or semantic_context.is_empty():
+            return "no-semantic-context"
+        payload = json.dumps(asdict(semantic_context), sort_keys=True, default=str)
+        return hashlib.md5(payload.encode()).hexdigest()
+
+    async def get_service_stats(self) -> dict[str, Any]:
         """Get service statistics."""
         stats = {
             "provider": self.ai_provider.provider_type.value,
             "provider_context_size": self.ai_provider.get_max_context_size(),
             "cache_enabled": self.cache is not None,
             "optimizer_enabled": self.query_optimizer is not None,
+            "execution_port_enabled": self.execution_port is not None,
             "timestamp": datetime.now().isoformat(),
         }
 
-        # Add cache stats if available
         if self.cache:
             cache_stats = await self.cache.get_stats()
             stats["cache_stats"] = cache_stats

--- a/src/nlp2sql/services/semantic_resolution_service.py
+++ b/src/nlp2sql/services/semantic_resolution_service.py
@@ -1,0 +1,195 @@
+"""Business semantic resolution and retrieval-plan enrichment."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..core.entities import (
+    DatabaseType,
+    QueryIntentContext,
+    RetrievalPlan,
+    SemanticContext,
+)
+from ..ports.semantic_resolver import SemanticResolverPort
+
+
+class SemanticResolutionService:
+    """Resolve semantic context and inject it into retrieval signals."""
+
+    def __init__(self, semantic_resolver: SemanticResolverPort | None = None) -> None:
+        self.semantic_resolver = semantic_resolver
+
+    @property
+    def is_configured(self) -> bool:
+        return self.semantic_resolver is not None
+
+    async def resolve(
+        self,
+        question: str,
+        retrieval_plan: RetrievalPlan,
+        database_type: DatabaseType,
+        semantic_context: SemanticContext | None = None,
+    ) -> tuple[SemanticContext, RetrievalPlan]:
+        base_context = semantic_context or SemanticContext()
+        resolved_context = base_context
+
+        if self.semantic_resolver is not None:
+            resolved_context = await self.semantic_resolver.resolve(
+                question=question,
+                retrieval_plan=retrieval_plan,
+                database_type=database_type,
+                semantic_context=base_context,
+            )
+
+        merged_context = self._merge_contexts(base_context, resolved_context)
+        enriched_plan = self._enrich_retrieval_plan(retrieval_plan, merged_context)
+        return merged_context, enriched_plan
+
+    def _enrich_retrieval_plan(self, retrieval_plan: RetrievalPlan, semantic_context: SemanticContext) -> RetrievalPlan:
+        if semantic_context.is_empty():
+            return retrieval_plan
+
+        semantic_terms = self._semantic_terms(semantic_context)
+        intent_context = retrieval_plan.intent_context
+        enriched_intent = QueryIntentContext(
+            intent=intent_context.intent,
+            business_terms=self._unique_ordered([*intent_context.business_terms, *semantic_terms]),
+            metrics=self._unique_ordered(
+                [*intent_context.metrics, *[metric.name for metric in semantic_context.metric_definitions]]
+            ),
+            dimensions=self._unique_ordered(
+                [*intent_context.dimensions, *[dimension.name for dimension in semantic_context.dimension_definitions]]
+            ),
+            time_grains=self._unique_ordered(
+                [*intent_context.time_grains, *semantic_context.preferred_time_logic]
+            ),
+            filters=self._unique_ordered(
+                [
+                    *intent_context.filters,
+                    *semantic_context.required_filters,
+                    *[
+                        mapping.filter_expression
+                        for mapping in semantic_context.entity_mappings
+                        if mapping.filter_expression
+                    ],
+                ]
+            ),
+            expected_operations=intent_context.expected_operations,
+            requires_aggregation=intent_context.requires_aggregation,
+            requires_join=intent_context.requires_join,
+            requires_ordering=intent_context.requires_ordering,
+            metadata={
+                **intent_context.metadata,
+                "semantic_domain": semantic_context.domain,
+            },
+        )
+
+        retrieval_query = " ".join(
+            self._unique_ordered(
+                [
+                    retrieval_plan.retrieval_query,
+                    semantic_context.domain or "",
+                    *semantic_context.canonical_tables,
+                    *semantic_context.supporting_tables[:3],
+                    *semantic_context.required_filters[:3],
+                    *semantic_terms[:6],
+                ]
+            )
+        ).strip()
+        example_query = " ".join(
+            self._unique_ordered(
+                [
+                    retrieval_plan.example_query,
+                    semantic_context.domain or "",
+                    *semantic_context.canonical_tables[:3],
+                    *[metric.name for metric in semantic_context.metric_definitions[:3]],
+                    *[dimension.name for dimension in semantic_context.dimension_definitions[:3]],
+                ]
+            )
+        ).strip()
+
+        metadata: dict[str, Any] = {
+            **retrieval_plan.metadata,
+            "semantic_context": semantic_context.to_metadata(),
+        }
+
+        return RetrievalPlan(
+            original_question=retrieval_plan.original_question,
+            normalized_question=retrieval_plan.normalized_question,
+            intent_context=enriched_intent,
+            retrieval_query=retrieval_query or retrieval_plan.retrieval_query,
+            example_query=example_query or retrieval_plan.example_query,
+            keyword_hints=self._unique_ordered([*retrieval_plan.keyword_hints, *semantic_terms]),
+            metadata=metadata,
+        )
+
+    def _merge_contexts(self, base_context: SemanticContext, resolved_context: SemanticContext) -> SemanticContext:
+        if base_context.is_empty():
+            return resolved_context
+        if resolved_context.is_empty():
+            return base_context
+
+        return SemanticContext(
+            domain=resolved_context.domain or base_context.domain,
+            entity_mappings=self._merge_objects(
+                base_context.entity_mappings,
+                resolved_context.entity_mappings,
+                key=lambda mapping: mapping.to_prompt_text(),
+            ),
+            metric_definitions=self._merge_objects(
+                base_context.metric_definitions,
+                resolved_context.metric_definitions,
+                key=lambda metric: metric.name,
+            ),
+            dimension_definitions=self._merge_objects(
+                base_context.dimension_definitions,
+                resolved_context.dimension_definitions,
+                key=lambda dimension: dimension.name,
+            ),
+            canonical_tables=self._unique_ordered([*base_context.canonical_tables, *resolved_context.canonical_tables]),
+            supporting_tables=self._unique_ordered([*base_context.supporting_tables, *resolved_context.supporting_tables]),
+            required_filters=self._unique_ordered([*base_context.required_filters, *resolved_context.required_filters]),
+            preferred_time_logic=self._unique_ordered(
+                [*base_context.preferred_time_logic, *resolved_context.preferred_time_logic]
+            ),
+            disallowed_tables=self._unique_ordered([*base_context.disallowed_tables, *resolved_context.disallowed_tables]),
+            prompt_hints=self._unique_ordered([*base_context.prompt_hints, *resolved_context.prompt_hints]),
+            rules=self._merge_objects(base_context.rules, resolved_context.rules, key=lambda rule: rule.name),
+            patterns=self._merge_objects(base_context.patterns, resolved_context.patterns, key=lambda pattern: pattern.name),
+            confidence=max(base_context.confidence, resolved_context.confidence),
+            metadata={**base_context.metadata, **resolved_context.metadata},
+        )
+
+    def _semantic_terms(self, semantic_context: SemanticContext) -> list[str]:
+        terms = []
+        if semantic_context.domain:
+            terms.append(semantic_context.domain)
+        terms.extend(semantic_context.canonical_tables)
+        terms.extend(mapping.source_term for mapping in semantic_context.entity_mappings)
+        terms.extend(mapping.resolved_value for mapping in semantic_context.entity_mappings)
+        terms.extend(metric.name for metric in semantic_context.metric_definitions)
+        terms.extend(dimension.name for dimension in semantic_context.dimension_definitions)
+        terms.extend(semantic_context.prompt_hints)
+        return self._unique_ordered([term for term in terms if term])
+
+    def _merge_objects(self, left: list[Any], right: list[Any], key) -> list[Any]:
+        seen: set[str] = set()
+        merged: list[Any] = []
+        for value in [*left, *right]:
+            signature = key(value)
+            if not signature or signature in seen:
+                continue
+            seen.add(signature)
+            merged.append(value)
+        return merged
+
+    def _unique_ordered(self, values: list[str]) -> list[str]:
+        seen: set[str] = set()
+        result: list[str] = []
+        for value in values:
+            normalized = value.strip()
+            if not normalized or normalized in seen:
+                continue
+            seen.add(normalized)
+            result.append(normalized)
+        return result

--- a/src/nlp2sql/services/semantic_validation_service.py
+++ b/src/nlp2sql/services/semantic_validation_service.py
@@ -1,0 +1,161 @@
+"""Semantic validation for executable but business-incorrect SQL."""
+
+from __future__ import annotations
+
+import re
+
+from ..core.entities import SemanticContext, SemanticIssue, SemanticValidationResult, SqlIntentPlan
+from ..ports.semantic_validator import SemanticValidatorPort
+
+
+class SemanticValidationService:
+    """Validate SQL against resolved business semantics."""
+
+    def __init__(self, semantic_validator: SemanticValidatorPort | None = None) -> None:
+        self.semantic_validator = semantic_validator
+
+    async def validate(
+        self,
+        sql: str,
+        semantic_context: SemanticContext | None,
+        sql_intent_plan: SqlIntentPlan | None = None,
+    ) -> SemanticValidationResult:
+        normalized_context = semantic_context or SemanticContext()
+        built_in_result = self._run_builtin_checks(sql, normalized_context, sql_intent_plan)
+
+        if self.semantic_validator is None:
+            return built_in_result
+
+        custom_result = await self.semantic_validator.validate(sql, normalized_context, sql_intent_plan)
+        merged_issues = [*built_in_result.issues, *custom_result.issues]
+        merged_warnings = [*built_in_result.warnings, *custom_result.warnings]
+
+        return SemanticValidationResult(
+            is_valid=not any(issue.severity == "error" for issue in merged_issues),
+            issues=merged_issues,
+            warnings=merged_warnings,
+            metadata={**built_in_result.metadata, **custom_result.metadata},
+        )
+
+    def _run_builtin_checks(
+        self,
+        sql: str,
+        semantic_context: SemanticContext,
+        sql_intent_plan: SqlIntentPlan | None,
+    ) -> SemanticValidationResult:
+        if semantic_context.is_empty() and sql_intent_plan is None:
+            return SemanticValidationResult(is_valid=True)
+
+        issues: list[SemanticIssue] = []
+        warnings: list[str] = []
+        normalized_sql = self._normalize(sql)
+        tables_used = self._extract_tables(sql)
+
+        expected_tables = semantic_context.canonical_tables or []
+        if sql_intent_plan and sql_intent_plan.fact_table and not expected_tables:
+            expected_tables = [sql_intent_plan.fact_table]
+        if expected_tables and not set(expected_tables) & set(tables_used):
+            issues.append(
+                SemanticIssue(
+                    category="semantic_table_mismatch",
+                    message=f"Expected one of the canonical tables {expected_tables}, but SQL used {tables_used or ['none']}.",
+                    metadata={"expected_tables": expected_tables, "tables_used": tables_used},
+                )
+            )
+
+        disallowed_tables = self._unique_ordered(
+            [*semantic_context.disallowed_tables, *[table for rule in semantic_context.rules for table in rule.disallowed_tables]]
+        )
+        forbidden_hits = sorted(set(disallowed_tables) & set(tables_used))
+        if forbidden_hits:
+            issues.append(
+                SemanticIssue(
+                    category="disallowed_table",
+                    message=f"SQL uses disallowed tables for this business context: {', '.join(forbidden_hits)}.",
+                    metadata={"tables": forbidden_hits},
+                )
+            )
+
+        required_filters = self._unique_ordered(
+            [
+                *semantic_context.required_filters,
+                *[
+                    mapping.filter_expression
+                    for mapping in semantic_context.entity_mappings
+                    if mapping.filter_expression
+                ],
+                *[rule_filter for rule in semantic_context.rules for rule_filter in rule.required_filters],
+            ]
+        )
+        missing_filters = [
+            required_filter
+            for required_filter in required_filters
+            if self._normalize(required_filter) not in normalized_sql
+        ]
+        if missing_filters:
+            issues.append(
+                SemanticIssue(
+                    category="missing_required_filter",
+                    message=f"SQL is missing required business filters: {', '.join(missing_filters)}.",
+                    metadata={"filters": missing_filters},
+                )
+            )
+
+        required_dimensions = self._unique_ordered(
+            [
+                *[rule_dimension for rule in semantic_context.rules for rule_dimension in rule.required_dimensions],
+                *(
+                    sql_intent_plan.group_by
+                    if sql_intent_plan is not None
+                    else []
+                ),
+            ]
+        )
+        missing_dimensions = [
+            required_dimension
+            for required_dimension in required_dimensions
+            if self._normalize(required_dimension) not in normalized_sql
+        ]
+        if missing_dimensions:
+            issues.append(
+                SemanticIssue(
+                    category="missing_required_dimension",
+                    message=f"SQL is missing required business dimensions: {', '.join(missing_dimensions)}.",
+                    metadata={"dimensions": missing_dimensions},
+                )
+            )
+
+        if sql_intent_plan and sql_intent_plan.group_by and "group by" not in normalized_sql:
+            warnings.append(
+                "Structured plan expects grouped output but the generated SQL does not include GROUP BY."
+            )
+
+        return SemanticValidationResult(
+            is_valid=not any(issue.severity == "error" for issue in issues),
+            issues=issues,
+            warnings=warnings,
+            metadata={"tables_used": tables_used},
+        )
+
+    def _extract_tables(self, sql: str) -> list[str]:
+        matches = re.findall(r"\b(?:from|join)\s+([a-zA-Z0-9_.\"]+)", sql, flags=re.IGNORECASE)
+        tables: list[str] = []
+        for match in matches:
+            table_name = match.strip('"').split(".")[-1]
+            if table_name not in tables:
+                tables.append(table_name)
+        return tables
+
+    def _normalize(self, text: str) -> str:
+        return re.sub(r"\s+", " ", text.strip().lower())
+
+    def _unique_ordered(self, values: list[str]) -> list[str]:
+        seen: set[str] = set()
+        result: list[str] = []
+        for value in values:
+            normalized = value.strip()
+            if not normalized or normalized in seen:
+                continue
+            seen.add(normalized)
+            result.append(normalized)
+        return result

--- a/src/nlp2sql/services/sql_intent_planning_service.py
+++ b/src/nlp2sql/services/sql_intent_planning_service.py
@@ -1,0 +1,136 @@
+"""Create a structured SQL intent plan from retrieval and semantic signals."""
+
+from __future__ import annotations
+
+from ..core.entities import RetrievalPlan, SemanticContext, SqlIntentPlan
+
+
+class SqlIntentPlanningService:
+    """Build a narrow SQL plan before prompting the LLM."""
+
+    def build(
+        self,
+        retrieval_plan: RetrievalPlan,
+        semantic_context: SemanticContext,
+        relevant_tables: list[tuple[str, float]],
+        examples: list[dict[str, object]],
+    ) -> SqlIntentPlan:
+        disallowed_tables = self._unique_ordered(
+            [
+                *semantic_context.disallowed_tables,
+                *[
+                    table
+                    for rule in semantic_context.rules
+                    for table in rule.disallowed_tables
+                ],
+            ]
+        )
+        allowed_relevant_tables = [
+            (table, score)
+            for table, score in relevant_tables
+            if table not in disallowed_tables
+        ]
+        example_tables = []
+        for example in examples:
+            metadata = example.get("metadata", {})
+            if isinstance(metadata, dict):
+                example_tables.extend(metadata.get("tables", []))
+
+        preferred_rule_tables = [
+            table
+            for rule in semantic_context.rules
+            for table in rule.preferred_tables
+        ]
+        fact_table = None
+        if semantic_context.canonical_tables:
+            fact_table = semantic_context.canonical_tables[0]
+        elif preferred_rule_tables:
+            fact_table = preferred_rule_tables[0]
+        elif allowed_relevant_tables:
+            fact_table = allowed_relevant_tables[0][0]
+        elif relevant_tables:
+            fact_table = relevant_tables[0][0]
+
+        dimensions = self._unique_ordered(
+            [
+                *retrieval_plan.intent_context.dimensions,
+                *[dimension.name for dimension in semantic_context.dimension_definitions],
+                *[
+                    required_dimension
+                    for rule in semantic_context.rules
+                    for required_dimension in rule.required_dimensions
+                ],
+            ]
+        )
+        metrics = self._unique_ordered(
+            [
+                *retrieval_plan.intent_context.metrics,
+                *[metric.name for metric in semantic_context.metric_definitions],
+            ]
+        )
+        filters = self._unique_ordered(
+            [
+                *retrieval_plan.intent_context.filters,
+                *semantic_context.required_filters,
+                *[
+                    required_filter
+                    for rule in semantic_context.rules
+                    for required_filter in rule.required_filters
+                ],
+                *[
+                    mapping.filter_expression
+                    for mapping in semantic_context.entity_mappings
+                    if mapping.filter_expression
+                ],
+            ]
+        )
+        supporting_tables = self._unique_ordered(
+            [
+                *semantic_context.supporting_tables,
+                *preferred_rule_tables,
+                *[table for table, _ in allowed_relevant_tables if table != fact_table],
+                *example_tables,
+            ]
+        )
+        time_range = retrieval_plan.intent_context.time_grains[0] if retrieval_plan.intent_context.time_grains else None
+
+        group_by = (
+            dimensions
+            if retrieval_plan.intent_context.requires_aggregation
+            or retrieval_plan.intent_context.dimensions
+            or any(rule.required_dimensions for rule in semantic_context.rules)
+            else []
+        )
+        order_by = []
+        if retrieval_plan.intent_context.requires_ordering and metrics:
+            order_by = [f"{metrics[0]} DESC"]
+        elif metrics and fact_table:
+            order_by = [f"{metrics[0]} DESC"]
+
+        return SqlIntentPlan(
+            domain=semantic_context.domain,
+            fact_table=fact_table,
+            supporting_tables=supporting_tables[:5],
+            dimensions=dimensions,
+            metrics=metrics,
+            filters=filters,
+            time_range=time_range,
+            group_by=group_by,
+            order_by=order_by,
+            semantic_context_ref=semantic_context.domain,
+            metadata={
+                "candidate_tables": [table for table, _ in allowed_relevant_tables],
+                "example_tables": example_tables,
+            },
+        )
+
+    def _unique_ordered(self, values: list[str]) -> list[str]:
+        seen: set[str] = set()
+        result: list[str] = []
+        for value in values:
+            normalized = value.strip()
+            if not normalized or normalized in seen:
+                continue
+            seen.add(normalized)
+            result.append(normalized)
+        return result

--- a/src/nlp2sql/utils/artifact_loader.py
+++ b/src/nlp2sql/utils/artifact_loader.py
@@ -1,0 +1,202 @@
+"""Helpers for loading semantic context and example artifacts from JSON/YAML."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from ..core.entities import (
+    CanonicalQueryPattern,
+    DatabaseType,
+    DimensionDefinition,
+    DomainRule,
+    MetricDefinition,
+    SemanticContext,
+    SemanticEntityMapping,
+)
+from ..ports.example_repository import ExampleRepositoryPort
+from ..schema.example_store import ExampleStore
+
+
+def load_semantic_context(
+    *,
+    file_path: str | None = None,
+    inline_json: str | None = None,
+) -> SemanticContext | None:
+    """Load a semantic context artifact from file or inline JSON."""
+    payload = load_artifact_payload(
+        file_path=file_path,
+        inline_json=inline_json,
+        artifact_name="semantic context",
+    )
+    if payload is None:
+        return None
+    if not isinstance(payload, dict):
+        raise ValueError("Semantic context artifact must be a JSON/YAML object.")
+    return semantic_context_from_dict(payload)
+
+
+def load_examples_payload(
+    *,
+    file_path: str | None = None,
+    inline_json: str | None = None,
+    database_type: DatabaseType | None = None,
+) -> list[dict[str, Any]] | None:
+    """Load few-shot examples from file or inline JSON."""
+    payload = load_artifact_payload(
+        file_path=file_path,
+        inline_json=inline_json,
+        artifact_name="examples",
+    )
+    if payload is None:
+        return None
+    if not isinstance(payload, list):
+        raise ValueError("Examples artifact must be a JSON/YAML list.")
+    normalized_examples: list[dict[str, Any]] = []
+    for example in payload:
+        if not isinstance(example, dict):
+            raise ValueError("Each example must be an object with at least question and sql.")
+        if "question" not in example or "sql" not in example:
+            raise ValueError("Each example must contain 'question' and 'sql'.")
+        normalized_example = dict(example)
+        if database_type is not None:
+            normalized_example.setdefault("database_type", database_type.value)
+        normalized_example.setdefault("metadata", {})
+        normalized_examples.append(normalized_example)
+    return normalized_examples
+
+
+async def create_example_store_from_payload(
+    *,
+    examples: list[dict[str, Any]] | None,
+    database_url: str,
+    schema_name: str,
+    embedding_provider_type: str | None,
+    api_key: str | None = None,
+) -> ExampleRepositoryPort | None:
+    """Instantiate an ExampleStore from parsed examples."""
+    if not examples:
+        return None
+    from .. import create_embedding_provider
+
+    if embedding_provider_type is None:
+        try:
+            embedding_provider = create_embedding_provider(provider="local")
+        except Exception:
+            openai_api_key = os.getenv("OPENAI_API_KEY")
+            if not openai_api_key:
+                raise ValueError(
+                    "Few-shot examples require embeddings. Configure a local embedding dependency or provide an OpenAI API key."
+                ) from None
+            embedding_provider = create_embedding_provider(provider="openai", api_key=openai_api_key)
+    else:
+        embedding_provider = create_embedding_provider(
+            provider=embedding_provider_type,
+            api_key=api_key if embedding_provider_type == "openai" else None,
+        )
+    example_store = ExampleStore(
+        embedding_provider=embedding_provider,
+        database_url=database_url,
+        schema_name=schema_name,
+    )
+    await example_store.add_examples(examples)
+    return example_store
+
+
+def load_artifact_payload(
+    *,
+    file_path: str | None = None,
+    inline_json: str | None = None,
+    artifact_name: str,
+) -> Any:
+    """Load an artifact payload from one source only."""
+    if file_path and inline_json:
+        raise ValueError(f"Provide either {artifact_name} file or inline JSON, not both.")
+    if file_path:
+        return _load_artifact_file(file_path)
+    if inline_json:
+        try:
+            return json.loads(inline_json)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Invalid inline JSON for {artifact_name}: {exc.msg}.") from exc
+    return None
+
+
+def semantic_context_from_dict(payload: dict[str, Any]) -> SemanticContext:
+    """Map a dictionary into a SemanticContext entity."""
+    return SemanticContext(
+        domain=payload.get("domain"),
+        entity_mappings=[
+            SemanticEntityMapping(**mapping)
+            for mapping in _expect_list(payload.get("entity_mappings"), "entity_mappings")
+        ],
+        metric_definitions=[
+            MetricDefinition(**metric)
+            for metric in _expect_list(payload.get("metric_definitions"), "metric_definitions")
+        ],
+        dimension_definitions=[
+            DimensionDefinition(**dimension)
+            for dimension in _expect_list(payload.get("dimension_definitions"), "dimension_definitions")
+        ],
+        canonical_tables=_expect_string_list(payload.get("canonical_tables"), "canonical_tables"),
+        supporting_tables=_expect_string_list(payload.get("supporting_tables"), "supporting_tables"),
+        required_filters=_expect_string_list(payload.get("required_filters"), "required_filters"),
+        preferred_time_logic=_expect_string_list(payload.get("preferred_time_logic"), "preferred_time_logic"),
+        disallowed_tables=_expect_string_list(payload.get("disallowed_tables"), "disallowed_tables"),
+        prompt_hints=_expect_string_list(payload.get("prompt_hints"), "prompt_hints"),
+        rules=[DomainRule(**rule) for rule in _expect_list(payload.get("rules"), "rules")],
+        patterns=[
+            CanonicalQueryPattern(**pattern)
+            for pattern in _expect_list(payload.get("patterns"), "patterns")
+        ],
+        confidence=float(payload.get("confidence", 0.0)),
+        metadata=_expect_dict(payload.get("metadata"), "metadata"),
+    )
+
+
+def _load_artifact_file(file_path: str) -> Any:
+    path = Path(file_path)
+    if not path.exists():
+        raise ValueError(f"Artifact file not found: {file_path}")
+    content = path.read_text()
+    suffix = path.suffix.lower()
+    if suffix == ".json":
+        return json.loads(content)
+    if suffix in {".yaml", ".yml"}:
+        return yaml.safe_load(content)
+
+    stripped = content.lstrip()
+    if stripped.startswith("{") or stripped.startswith("["):
+        return json.loads(content)
+    return yaml.safe_load(content)
+
+
+def _expect_list(value: Any, field_name: str) -> list[dict[str, Any]]:
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        raise ValueError(f"'{field_name}' must be a list.")
+    for item in value:
+        if not isinstance(item, dict):
+            raise ValueError(f"'{field_name}' entries must be objects.")
+    return value
+
+
+def _expect_string_list(value: Any, field_name: str) -> list[str]:
+    if value is None:
+        return []
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        raise ValueError(f"'{field_name}' must be a list of strings.")
+    return value
+
+
+def _expect_dict(value: Any, field_name: str) -> dict[str, Any]:
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        raise ValueError(f"'{field_name}' must be an object.")
+    return value

--- a/src/nlp2sql/utils/semantic_prompt.py
+++ b/src/nlp2sql/utils/semantic_prompt.py
@@ -1,0 +1,186 @@
+"""Helpers to render rich semantic context into LLM prompts."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def format_semantic_context_lines(semantic_context: dict[str, Any]) -> list[str]:
+    """Render semantic context metadata into concise prompt lines."""
+    lines: list[str] = ["Business Context:"]
+
+    if semantic_context.get("domain"):
+        lines.append(f"- Domain: {semantic_context['domain']}")
+    if semantic_context.get("canonical_tables"):
+        lines.append(f"- Preferred tables: {', '.join(semantic_context['canonical_tables'])}")
+    if semantic_context.get("supporting_tables"):
+        lines.append(f"- Supporting tables: {', '.join(semantic_context['supporting_tables'][:5])}")
+    if semantic_context.get("required_filters"):
+        lines.append(f"- Required filters: {', '.join(semantic_context['required_filters'])}")
+    if semantic_context.get("disallowed_tables"):
+        lines.append(f"- Avoid tables: {', '.join(semantic_context['disallowed_tables'])}")
+    if semantic_context.get("preferred_time_logic"):
+        lines.append(f"- Time logic: {', '.join(semantic_context['preferred_time_logic'])}")
+    if semantic_context.get("prompt_hints"):
+        lines.append(f"- Hints: {', '.join(semantic_context['prompt_hints'])}")
+
+    entity_mapping_lines = _format_entity_mappings(semantic_context.get("entity_mappings"))
+    if entity_mapping_lines:
+        lines.append("- Entity mappings:")
+        lines.extend(entity_mapping_lines)
+
+    metric_lines = _format_metric_definitions(semantic_context.get("metric_definitions"))
+    if metric_lines:
+        lines.append("- Metric definitions:")
+        lines.extend(metric_lines)
+
+    dimension_lines = _format_dimension_definitions(semantic_context.get("dimension_definitions"))
+    if dimension_lines:
+        lines.append("- Dimension definitions:")
+        lines.extend(dimension_lines)
+
+    rule_lines = _format_rules(semantic_context.get("rules"))
+    if rule_lines:
+        lines.append("- Business rules:")
+        lines.extend(rule_lines)
+
+    pattern_lines = _format_patterns(semantic_context.get("patterns"))
+    if pattern_lines:
+        lines.append("- Canonical query patterns:")
+        lines.extend(pattern_lines)
+
+    return lines
+
+
+def format_sql_intent_plan_lines(sql_intent_plan: dict[str, Any]) -> list[str]:
+    """Render structured SQL intent metadata into concise prompt lines."""
+    lines: list[str] = ["SQL Intent Plan:"]
+
+    if sql_intent_plan.get("fact_table"):
+        lines.append(f"- Fact table: {sql_intent_plan['fact_table']}")
+    if sql_intent_plan.get("supporting_tables"):
+        lines.append(f"- Supporting tables: {', '.join(sql_intent_plan['supporting_tables'])}")
+    if sql_intent_plan.get("dimensions"):
+        lines.append(f"- Dimensions: {', '.join(sql_intent_plan['dimensions'])}")
+    if sql_intent_plan.get("metrics"):
+        lines.append(f"- Metrics: {', '.join(sql_intent_plan['metrics'])}")
+    if sql_intent_plan.get("filters"):
+        lines.append(f"- Filters: {', '.join(sql_intent_plan['filters'])}")
+    if sql_intent_plan.get("group_by"):
+        lines.append(f"- Group by: {', '.join(sql_intent_plan['group_by'])}")
+    if sql_intent_plan.get("order_by"):
+        lines.append(f"- Order by: {', '.join(sql_intent_plan['order_by'])}")
+    if sql_intent_plan.get("time_range"):
+        lines.append(f"- Time range: {sql_intent_plan['time_range']}")
+
+    return lines
+
+
+def _format_entity_mappings(entity_mappings: Any) -> list[str]:
+    lines: list[str] = []
+    if not isinstance(entity_mappings, list):
+        return lines
+
+    for mapping in entity_mappings[:5]:
+        if isinstance(mapping, dict):
+            prompt_text = mapping.get("prompt_text")
+            if prompt_text:
+                lines.append(f"  - {prompt_text}")
+                continue
+
+            source_term = mapping.get("source_term", "unknown")
+            target = mapping.get("target", "unknown")
+            resolved_value = mapping.get("resolved_value", "unknown")
+            lines.append(f"  - {source_term} -> {target} = {resolved_value}")
+        elif isinstance(mapping, str) and mapping.strip():
+            lines.append(f"  - {mapping}")
+
+    return lines
+
+
+def _format_metric_definitions(metric_definitions: Any) -> list[str]:
+    lines: list[str] = []
+    if not isinstance(metric_definitions, list):
+        return lines
+
+    for metric in metric_definitions[:8]:
+        if isinstance(metric, dict):
+            parts = [str(metric.get("name", "unknown"))]
+            if metric.get("description"):
+                parts.append(str(metric["description"]))
+            if metric.get("expression"):
+                parts.append(f"expr={metric['expression']}")
+            if metric.get("synonyms"):
+                parts.append(f"synonyms={', '.join(metric['synonyms'][:5])}")
+            lines.append(f"  - {' | '.join(parts)}")
+        elif isinstance(metric, str) and metric.strip():
+            lines.append(f"  - {metric}")
+
+    return lines
+
+
+def _format_dimension_definitions(dimension_definitions: Any) -> list[str]:
+    lines: list[str] = []
+    if not isinstance(dimension_definitions, list):
+        return lines
+
+    for dimension in dimension_definitions[:8]:
+        if isinstance(dimension, dict):
+            parts = [str(dimension.get("name", "unknown"))]
+            if dimension.get("description"):
+                parts.append(str(dimension["description"]))
+            if dimension.get("allowed_values"):
+                parts.append(f"values={', '.join(dimension['allowed_values'][:5])}")
+            if dimension.get("synonyms"):
+                parts.append(f"synonyms={', '.join(dimension['synonyms'][:5])}")
+            lines.append(f"  - {' | '.join(parts)}")
+        elif isinstance(dimension, str) and dimension.strip():
+            lines.append(f"  - {dimension}")
+
+    return lines
+
+
+def _format_rules(rules: Any) -> list[str]:
+    lines: list[str] = []
+    if not isinstance(rules, list):
+        return lines
+
+    for rule in rules[:5]:
+        if not isinstance(rule, dict):
+            continue
+
+        parts = [str(rule.get("name", "rule"))]
+        if rule.get("description"):
+            parts.append(str(rule["description"]))
+        if rule.get("required_dimensions"):
+            parts.append(f"requires_dimensions={', '.join(rule['required_dimensions'])}")
+        if rule.get("required_filters"):
+            parts.append(f"requires_filters={', '.join(rule['required_filters'])}")
+        if rule.get("preferred_tables"):
+            parts.append(f"preferred_tables={', '.join(rule['preferred_tables'])}")
+        lines.append(f"  - {' | '.join(parts)}")
+
+    return lines
+
+
+def _format_patterns(patterns: Any) -> list[str]:
+    lines: list[str] = []
+    if not isinstance(patterns, list):
+        return lines
+
+    for pattern in patterns[:5]:
+        if not isinstance(pattern, dict):
+            continue
+
+        parts = [str(pattern.get("name", "pattern"))]
+        if pattern.get("description"):
+            parts.append(str(pattern["description"]))
+        if pattern.get("metric_names"):
+            parts.append(f"metrics={', '.join(pattern['metric_names'])}")
+        if pattern.get("dimension_names"):
+            parts.append(f"dimensions={', '.join(pattern['dimension_names'])}")
+        if pattern.get("preferred_tables"):
+            parts.append(f"tables={', '.join(pattern['preferred_tables'])}")
+        lines.append(f"  - {' | '.join(parts)}")
+
+    return lines

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,7 +24,17 @@ POSTGRES_DB = os.getenv("NLP2SQL_TEST_POSTGRES_DB", "testdb")
 POSTGRES_URL = f"postgresql://{POSTGRES_USER}:{POSTGRES_PASS}@{POSTGRES_HOST}:{POSTGRES_PORT}/{POSTGRES_DB}"
 
 # Expected tables from docker/init-schema.sql
-EXPECTED_TABLES = {"users", "categories", "products", "orders", "order_items", "reviews"}
+EXPECTED_TABLES = {
+    "stores",
+    "marketing_channels",
+    "users",
+    "categories",
+    "products",
+    "orders",
+    "order_items",
+    "reviews",
+    "daily_channel_metrics",
+}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_artifact_loader.py
+++ b/tests/test_artifact_loader.py
@@ -1,0 +1,65 @@
+"""Tests for JSON/YAML semantic and examples artifact loading."""
+
+from pathlib import Path
+
+import yaml
+
+from nlp2sql.core.entities import DatabaseType
+from nlp2sql.utils.artifact_loader import load_examples_payload, load_semantic_context
+
+
+def test_load_semantic_context_from_json(tmp_path: Path):
+    semantic_file = tmp_path / "semantic.json"
+    semantic_file.write_text(
+        """{
+  "domain": "sales",
+  "canonical_tables": ["channel_performance"],
+  "required_filters": ["segment = 'growth'"]
+}"""
+    )
+
+    semantic_context = load_semantic_context(file_path=str(semantic_file))
+
+    assert semantic_context is not None
+    assert semantic_context.domain == "sales"
+    assert semantic_context.canonical_tables == ["channel_performance"]
+
+
+def test_load_semantic_context_from_yaml(tmp_path: Path):
+    semantic_file = tmp_path / "semantic.yaml"
+    semantic_file.write_text(
+        yaml.safe_dump(
+            {
+                "domain": "conversion",
+                "canonical_tables": ["conversion_funnel"],
+                "required_filters": ["region = 'north_america'"],
+            }
+        )
+    )
+
+    semantic_context = load_semantic_context(file_path=str(semantic_file))
+
+    assert semantic_context is not None
+    assert semantic_context.domain == "conversion"
+    assert semantic_context.required_filters == ["region = 'north_america'"]
+
+
+def test_load_examples_payload_from_json(tmp_path: Path):
+    examples_file = tmp_path / "examples.json"
+    examples_file.write_text(
+        """[
+  {
+    "question": "Revenue by channel",
+    "sql": "SELECT channel, SUM(net_revenue) FROM channel_performance GROUP BY channel"
+  }
+]"""
+    )
+
+    examples = load_examples_payload(
+        file_path=str(examples_file),
+        database_type=DatabaseType.REDSHIFT,
+    )
+
+    assert examples is not None
+    assert examples[0]["database_type"] == "redshift"
+    assert examples[0]["metadata"] == {}

--- a/tests/test_cli_semantic_support.py
+++ b/tests/test_cli_semantic_support.py
@@ -1,0 +1,138 @@
+"""Tests for CLI semantic context and few-shot example support."""
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from click.testing import CliRunner
+
+from nlp2sql.cli import cli
+
+
+def test_query_accepts_semantic_context_and_examples_and_prints_metadata(tmp_path: Path):
+    runner = CliRunner()
+    semantic_file = tmp_path / "semantic.json"
+    semantic_file.write_text(
+        """{
+  "domain": "sales",
+  "canonical_tables": ["channel_performance"],
+  "required_filters": ["segment = 'growth'"]
+}"""
+    )
+    examples_file = tmp_path / "examples.json"
+    examples_file.write_text(
+        """[
+  {
+    "question": "Revenue by channel",
+    "sql": "SELECT channel, SUM(net_revenue) FROM channel_performance GROUP BY channel",
+    "database_type": "redshift"
+  }
+]"""
+    )
+
+    fake_service = MagicMock()
+    fake_service.generate_sql = AsyncMock(
+        return_value={
+            "sql": "SELECT 1",
+            "confidence": 0.9,
+            "tokens_used": 42,
+            "validation": {"is_valid": True},
+            "metadata": {
+                "semantic_context": {"domain": "sales"},
+                "sql_intent_plan": {"fact_table": "channel_performance"},
+                "selected_examples": [{"tables": ["channel_performance"]}],
+            },
+        }
+    )
+    fake_example_store = MagicMock()
+
+    with (
+        patch("nlp2sql.cli.create_and_initialize_service", new_callable=AsyncMock) as create_service,
+        patch("nlp2sql.cli.create_example_store_from_payload", new_callable=AsyncMock) as create_example_store,
+    ):
+        create_service.return_value = fake_service
+        create_example_store.return_value = fake_example_store
+
+        result = runner.invoke(
+            cli,
+            [
+                "query",
+                "--database-url",
+                "redshift://user:pass@host:5439/db",
+                "--question",
+                "give me sales metrics",
+                "--provider",
+                "openai",
+                "--embedding-provider",
+                "openai",
+                "--semantic-context-file",
+                str(semantic_file),
+                "--examples-file",
+                str(examples_file),
+                "--show-semantic-context",
+                "--show-sql-intent-plan",
+                "--show-selected-examples",
+                "--validate",
+            ],
+            env={"OPENAI_API_KEY": "test-key"},
+        )
+
+    assert result.exit_code == 0, result.output
+    assert create_service.await_args.kwargs["example_store"] is fake_example_store
+    assert fake_service.generate_sql.await_args.kwargs["semantic_context"].domain == "sales"
+    assert fake_service.generate_sql.await_args.kwargs["execution_mode"] == "generate_and_validate"
+    assert "Semantic Context:" in result.output
+    assert "SQL Intent Plan:" in result.output
+    assert "Selected Examples:" in result.output
+
+
+def test_benchmark_uses_detected_database_type(tmp_path: Path):
+    runner = CliRunner()
+    questions_file = tmp_path / "questions.txt"
+    questions_file.write_text("show conversion metrics\n")
+    semantic_file = tmp_path / "semantic.yaml"
+    semantic_file.write_text(
+        "domain: conversion\ncanonical_tables:\n  - conversion_funnel\n"
+    )
+
+    fake_service = MagicMock()
+    fake_service.generate_sql = AsyncMock(
+        return_value={
+            "sql": "SELECT 1",
+            "confidence": 0.8,
+            "tokens_used": 5,
+            "validation": {"is_valid": True},
+            "metadata": {},
+        }
+    )
+
+    with (
+        patch("nlp2sql.cli.create_and_initialize_service", new_callable=AsyncMock) as create_service,
+        patch("nlp2sql.cli.create_example_store_from_payload", new_callable=AsyncMock) as create_example_store,
+    ):
+        create_service.return_value = fake_service
+        create_example_store.return_value = None
+
+        result = runner.invoke(
+            cli,
+            [
+                "benchmark",
+                "--database-url",
+                "redshift://user:pass@host:5439/db",
+                "--schema",
+                "analytics",
+                "--questions",
+                str(questions_file),
+                "--providers",
+                "openai",
+                "--iterations",
+                "1",
+                "--semantic-context-file",
+                str(semantic_file),
+            ],
+            env={"OPENAI_API_KEY": "test-key"},
+        )
+
+    assert result.exit_code == 0, result.output
+    assert create_service.await_args.kwargs["database_type"].value == "redshift"
+    assert fake_service.generate_sql.await_args.kwargs["database_type"].value == "redshift"
+    assert fake_service.generate_sql.await_args.kwargs["semantic_context"].domain == "conversion"

--- a/tests/test_client_hooks.py
+++ b/tests/test_client_hooks.py
@@ -1,0 +1,160 @@
+"""Tests for the high-level DSL execution hooks and modes."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from nlp2sql.client import NLP2SQL, connect
+from nlp2sql.core.entities import DatabaseType, DimensionDefinition, MetricDefinition, SemanticContext
+from nlp2sql.core.runtime import ExecutionHooks, ExecutionMode, SemanticHooks
+
+
+class TestNLP2SQLAskModes:
+    """Ensure the public DSL resolves execution mode idiomatically."""
+
+    @pytest.mark.asyncio
+    async def test_ask_defaults_to_generate_only(self):
+        service = MagicMock()
+        service.generate_sql = AsyncMock(
+            return_value={
+                "sql": "SELECT 1",
+                "confidence": 1.0,
+                "provider": "openai",
+                "database_type": "postgres",
+                "validation": {"is_valid": True},
+                "metadata": {},
+            }
+        )
+        client = NLP2SQL(service=service, database_type=DatabaseType.POSTGRES)
+
+        await client.ask("test question")
+
+        assert service.generate_sql.await_args.kwargs["execution_mode"] == ExecutionMode.GENERATE_ONLY.value
+
+    @pytest.mark.asyncio
+    async def test_ask_validate_and_repair_flags_map_to_mode(self):
+        service = MagicMock()
+        service.generate_sql = AsyncMock(
+            return_value={
+                "sql": "SELECT 1",
+                "confidence": 1.0,
+                "provider": "openai",
+                "database_type": "postgres",
+                "validation": {"is_valid": True},
+                "metadata": {},
+            }
+        )
+        client = NLP2SQL(service=service, database_type=DatabaseType.POSTGRES)
+
+        await client.ask("test question", validate=True, repair=True)
+
+        assert service.generate_sql.await_args.kwargs["execution_mode"] == ExecutionMode.GENERATE_VALIDATE_REPAIR.value
+
+    @pytest.mark.asyncio
+    async def test_explicit_execution_mode_wins_over_flags(self):
+        service = MagicMock()
+        service.generate_sql = AsyncMock(
+            return_value={
+                "sql": "SELECT 1",
+                "confidence": 1.0,
+                "provider": "openai",
+                "database_type": "postgres",
+                "validation": {"is_valid": True},
+                "metadata": {},
+            }
+        )
+        client = NLP2SQL(service=service, database_type=DatabaseType.POSTGRES)
+
+        await client.ask("test question", execution_mode=ExecutionMode.GENERATE_AND_VALIDATE, repair=True)
+
+        assert service.generate_sql.await_args.kwargs["execution_mode"] == ExecutionMode.GENERATE_AND_VALIDATE.value
+
+    @pytest.mark.asyncio
+    async def test_ask_forwards_default_semantic_context(self):
+        service = MagicMock()
+        service.generate_sql = AsyncMock(
+            return_value={
+                "sql": "SELECT 1",
+                "confidence": 1.0,
+                "provider": "openai",
+                "database_type": "postgres",
+                "validation": {"is_valid": True},
+                "metadata": {},
+            }
+        )
+        semantic_context = SemanticContext(domain="non_paid")
+        client = NLP2SQL(service=service, database_type=DatabaseType.POSTGRES, semantic_context=semantic_context)
+
+        await client.ask("test question")
+
+        assert service.generate_sql.await_args.kwargs["semantic_context"] is semantic_context
+
+    @pytest.mark.asyncio
+    async def test_ask_accepts_rich_per_request_funnel_context(self):
+        service = MagicMock()
+        service.generate_sql = AsyncMock(
+            return_value={
+                "sql": "SELECT 1",
+                "confidence": 1.0,
+                "provider": "openai",
+                "database_type": "postgres",
+                "validation": {"is_valid": True},
+                "metadata": {},
+            }
+        )
+        client = NLP2SQL(service=service, database_type=DatabaseType.POSTGRES)
+        semantic_context = SemanticContext(
+            domain="funnel",
+            canonical_tables=["conversion_funnel"],
+            metric_definitions=[
+                MetricDefinition(name="sessions"),
+                MetricDefinition(name="cvr", expression="SUM(conversions)::float / NULLIF(SUM(sessions), 0)"),
+            ],
+            dimension_definitions=[DimensionDefinition(name="source_category")],
+        )
+
+        await client.ask(
+            "show sessions and cvr by source category",
+            semantic_context=semantic_context,
+        )
+
+        assert service.generate_sql.await_args.kwargs["semantic_context"] is semantic_context
+
+
+class TestConnectHooks:
+    """Ensure grouped hooks are forwarded by the public `connect()` API."""
+
+    @pytest.mark.asyncio
+    async def test_connect_accepts_grouped_hooks(self):
+        fake_service = MagicMock()
+        execution_port = MagicMock()
+        error_classifier = MagicMock()
+        repair_policy = MagicMock()
+        semantic_resolver = MagicMock()
+        semantic_validator = MagicMock()
+        semantic_context = SemanticContext(domain="funnel")
+
+        with patch("nlp2sql.create_and_initialize_service", new_callable=AsyncMock) as create_service:
+            create_service.return_value = fake_service
+
+            client = await connect(
+                "postgresql://user:pass@localhost/db",
+                hooks=ExecutionHooks(
+                    execution_port=execution_port,
+                    error_classifier=error_classifier,
+                    repair_policy=repair_policy,
+                ),
+                semantic_hooks=SemanticHooks(
+                    semantic_resolver=semantic_resolver,
+                    semantic_validator=semantic_validator,
+                    semantic_context=semantic_context,
+                ),
+            )
+
+        assert isinstance(client, NLP2SQL)
+        assert create_service.await_args.kwargs["execution_port"] is execution_port
+        assert create_service.await_args.kwargs["error_classifier"] is error_classifier
+        assert create_service.await_args.kwargs["repair_policy"] is repair_policy
+        assert create_service.await_args.kwargs["semantic_resolver"] is semantic_resolver
+        assert create_service.await_args.kwargs["semantic_validator"] is semantic_validator
+        assert client._semantic_context is semantic_context

--- a/tests/test_database_prompts.py
+++ b/tests/test_database_prompts.py
@@ -44,6 +44,9 @@ class TestGetDatabaseHint:
         assert "LISTAGG" in hint
         assert "DISTINCT ON" in hint
         assert "generate_series" in hint
+        assert "QUALIFY" in hint
+        assert "NOW()" in hint
+        assert "INTERVAL" in hint
 
     def test_unknown_type_returns_empty_string(self):
         assert get_database_hint("unknown_db") == ""

--- a/tests/test_dsl_integration.py
+++ b/tests/test_dsl_integration.py
@@ -7,8 +7,16 @@ import pytest
 import nlp2sql as lib
 from nlp2sql import ProviderConfig
 from nlp2sql.client import NLP2SQL
-from nlp2sql.core.entities import DatabaseType
+from nlp2sql.core.entities import (
+    DatabaseType,
+    DimensionDefinition,
+    DomainRule,
+    MetricDefinition,
+    SemanticContext,
+    SemanticEntityMapping,
+)
 from nlp2sql.core.result import QueryResult
+from nlp2sql.ports.ai_provider import QueryContext, QueryResponse
 from nlp2sql.schema.example_store import ExampleStore
 from nlp2sql.services.query_service import QueryGenerationService
 
@@ -33,7 +41,111 @@ _TEST_EXAMPLES = [
         ),
         "database_type": "postgres",
     },
+    {
+        "question": "Show daily revenue by source category for the flagship North America store",
+        "sql": (
+            "SELECT d.metric_date, mc.source_category, SUM(d.orders_count) AS orders_count, "
+            "SUM(d.revenue) AS revenue "
+            "FROM daily_channel_metrics d "
+            "JOIN stores s ON d.store_id = s.id "
+            "JOIN marketing_channels mc ON d.channel_id = mc.id "
+            "WHERE s.code = 'na_flagship' AND s.region = 'North America' "
+            "GROUP BY d.metric_date, mc.source_category"
+        ),
+        "database_type": "postgres",
+        "metadata": {"tables": ["daily_channel_metrics", "stores", "marketing_channels"]},
+    },
 ]
+
+
+@pytest.fixture(autouse=True)
+def isolate_local_indexes(tmp_path, monkeypatch):
+    """Keep schema/example indexes isolated per test to avoid cache collisions."""
+    monkeypatch.setenv("NLP2SQL_EMBEDDINGS_DIR", str(tmp_path / "embeddings"))
+    monkeypatch.setenv("NLP2SQL_EXAMPLES_DIR", str(tmp_path / "examples"))
+
+
+def _build_channel_performance_semantic_context() -> SemanticContext:
+    return SemanticContext(
+        domain="ecommerce_channel_performance",
+        canonical_tables=["daily_channel_metrics"],
+        required_filters=["s.code = 'na_flagship'", "s.region = 'North America'"],
+        disallowed_tables=["orders"],
+        prompt_hints=[
+            "Prefer the aggregated daily channel metrics fact table for source-category performance questions."
+        ],
+        entity_mappings=[
+            SemanticEntityMapping(
+                source_term="North America flagship store",
+                target="store_scope",
+                resolved_value="na_flagship / North America",
+                filter_expression="s.code = 'na_flagship' AND s.region = 'North America'",
+            )
+        ],
+        metric_definitions=[
+            MetricDefinition(name="revenue", description="Revenue aggregated by day and source category."),
+            MetricDefinition(name="orders_count", description="Order count aggregated by day and source category."),
+            MetricDefinition(
+                name="conversion_rate",
+                expression="SUM(d.orders_count)::float / NULLIF(SUM(d.sessions), 0)",
+                description="Orders divided by sessions on the daily channel metrics fact table.",
+            ),
+        ],
+        dimension_definitions=[
+            DimensionDefinition(name="metric_date", description="Daily grain for channel performance."),
+            DimensionDefinition(name="source_category", description="Channel grouping dimension."),
+        ],
+        rules=[
+            DomainRule(
+                name="preserve_source_breakdown",
+                description="Keep source_category when the user asks for a source breakdown.",
+                required_dimensions=["source_category"],
+                preferred_tables=["daily_channel_metrics"],
+            )
+        ],
+    )
+
+
+class SemanticAwareMockAIProvider(MockAIProvider):
+    """Mock provider that reacts to semantic planning metadata."""
+
+    async def generate_query(self, context: QueryContext) -> QueryResponse:
+        metadata = context.metadata or {}
+        semantic_context = metadata.get("semantic_context", {})
+        sql_intent_plan = metadata.get("sql_intent_plan", {})
+
+        if (
+            semantic_context.get("domain") == "ecommerce_channel_performance"
+            and sql_intent_plan.get("fact_table") == "daily_channel_metrics"
+            and "source_category" in sql_intent_plan.get("dimensions", [])
+        ):
+            return QueryResponse(
+                sql=(
+                    "SELECT d.metric_date, mc.source_category, "
+                    "SUM(d.orders_count) AS orders_count, SUM(d.revenue) AS revenue "
+                    "FROM daily_channel_metrics d "
+                    "JOIN stores s ON d.store_id = s.id "
+                    "JOIN marketing_channels mc ON d.channel_id = mc.id "
+                    "WHERE s.code = 'na_flagship' AND s.region = 'North America' "
+                    "GROUP BY d.metric_date, mc.source_category "
+                    "ORDER BY d.metric_date, revenue DESC"
+                ),
+                explanation="Use aggregated daily channel metrics for source-category ecommerce performance.",
+                confidence=0.99,
+                tokens_used=120,
+                provider="mock-semantic",
+            )
+
+        return QueryResponse(
+            sql=(
+                "SELECT DATE(order_date) AS order_day, COUNT(*) AS orders_count, SUM(total_amount) AS revenue "
+                "FROM orders GROUP BY DATE(order_date) ORDER BY order_day"
+            ),
+            explanation="Fallback to transactional orders table without semantic business guidance.",
+            confidence=0.7,
+            tokens_used=80,
+            provider="mock-semantic",
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -138,6 +250,65 @@ class TestAskDSL:
         assert isinstance(result, QueryResult)
         assert result.sql
 
+    async def test_ask_with_in_memory_semantic_context(self, postgres_available, mock_embedding_provider):
+        nlp = await lib.connect(
+            postgres_available,
+            provider=ProviderConfig(provider="openai", api_key="fake"),
+            embedding_provider=mock_embedding_provider,
+            examples=_TEST_EXAMPLES,
+        )
+        nlp._service.ai_provider = SemanticAwareMockAIProvider()
+
+        result = await nlp.ask(
+            "Show daily revenue and order count by source category for the North America flagship store",
+            semantic_context=_build_channel_performance_semantic_context(),
+        )
+
+        assert isinstance(result, QueryResult)
+        assert "daily_channel_metrics" in result.sql
+        assert "source_category" in result.sql
+        assert result.metadata["sql_intent_plan"]["fact_table"] == "daily_channel_metrics"
+        assert "source_category" in result.metadata["sql_intent_plan"]["dimensions"]
+
+        execution = await nlp._service.schema_repository.execute_query(result.sql)
+        assert execution["row_count"] > 0
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+class TestSemanticRegressionScenario:
+    """Reproduce a wrong-choice path and prove semantic guidance fixes it."""
+
+    async def test_semantic_context_shifts_from_orders_to_daily_channel_metrics(
+        self,
+        postgres_available,
+        mock_embedding_provider,
+    ):
+        nlp = await lib.connect(
+            postgres_available,
+            provider=ProviderConfig(provider="openai", api_key="fake"),
+            embedding_provider=mock_embedding_provider,
+            examples=_TEST_EXAMPLES,
+        )
+        nlp._service.ai_provider = SemanticAwareMockAIProvider()
+        question = "Show daily revenue and order count by source category for the North America flagship store"
+
+        baseline = await nlp.ask(question)
+        assert "FROM orders" in baseline.sql
+        baseline_execution = await nlp._service.schema_repository.execute_query(baseline.sql)
+        assert baseline_execution["row_count"] > 0
+
+        enriched = await nlp.ask(
+            question,
+            semantic_context=_build_channel_performance_semantic_context(),
+        )
+        assert "FROM daily_channel_metrics" in enriched.sql
+        assert enriched.metadata["sql_intent_plan"]["fact_table"] == "daily_channel_metrics"
+        assert "source_category" in enriched.metadata["sql_intent_plan"]["group_by"]
+
+        enriched_execution = await nlp._service.schema_repository.execute_query(enriched.sql)
+        assert enriched_execution["row_count"] > 0
+
 
 @pytest.mark.integration
 @pytest.mark.asyncio
@@ -179,8 +350,8 @@ class TestEndToEndWithRealAI:
     def require_api_key(self, tmp_path, monkeypatch):
         if not os.getenv("OPENAI_API_KEY"):
             pytest.skip("OPENAI_API_KEY not set")
-        # Isolate FAISS indexes so mock-dimension caches don't clash
-        monkeypatch.setenv("NLP2SQL_DATA_DIR", str(tmp_path))
+        monkeypatch.setenv("NLP2SQL_EMBEDDINGS_DIR", str(tmp_path / "embeddings"))
+        monkeypatch.setenv("NLP2SQL_EXAMPLES_DIR", str(tmp_path / "examples"))
 
     async def test_generate_valid_sql(self, postgres_available):
         nlp = await lib.connect(

--- a/tests/test_postgres_integration.py
+++ b/tests/test_postgres_integration.py
@@ -34,7 +34,56 @@ class TestPostgresRepository:
         assert users_table is not None
 
         column_names = {c["name"].lower() for c in users_table.columns}
-        expected = {"id", "email", "first_name", "last_name", "city", "country", "is_active"}
+        expected = {
+            "id",
+            "email",
+            "first_name",
+            "last_name",
+            "city",
+            "country",
+            "region",
+            "customer_segment",
+            "preferred_store_id",
+            "is_active",
+        }
+        assert expected.issubset(column_names), f"Missing columns: {expected - column_names}"
+
+    async def test_store_and_channel_dimensions_exist(self, postgres_available):
+        repo = PostgreSQLRepository(postgres_available)
+        await repo.initialize()
+
+        tables = await repo.get_tables()
+        stores_table = next((t for t in tables if t.name.lower() == "stores"), None)
+        channels_table = next((t for t in tables if t.name.lower() == "marketing_channels"), None)
+
+        assert stores_table is not None
+        assert channels_table is not None
+
+        store_columns = {c["name"].lower() for c in stores_table.columns}
+        channel_columns = {c["name"].lower() for c in channels_table.columns}
+
+        assert {"code", "domain", "region", "country", "currency"}.issubset(store_columns)
+        assert {"channel_name", "source_category", "traffic_type", "is_paid"}.issubset(channel_columns)
+
+    async def test_daily_channel_metrics_columns_exist(self, postgres_available):
+        repo = PostgreSQLRepository(postgres_available)
+        await repo.initialize()
+
+        tables = await repo.get_tables()
+        metrics_table = next((t for t in tables if t.name.lower() == "daily_channel_metrics"), None)
+        assert metrics_table is not None
+
+        column_names = {c["name"].lower() for c in metrics_table.columns}
+        expected = {
+            "metric_date",
+            "store_id",
+            "channel_id",
+            "sessions",
+            "add_to_cart_sessions",
+            "checkout_sessions",
+            "orders_count",
+            "revenue",
+        }
         assert expected.issubset(column_names), f"Missing columns: {expected - column_names}"
 
     async def test_returns_only_tables_not_views(self, postgres_available):
@@ -45,6 +94,7 @@ class TestPostgresRepository:
         names = {t.name.lower() for t in tables}
         assert EXPECTED_TABLES.issubset(names)
         assert "order_summaries" not in names  # views are excluded
+        assert "store_channel_sales" not in names  # views are excluded
 
     async def test_safe_query_check(self, postgres_available):
         safe, _ = is_safe_query("SELECT COUNT(*) FROM users")

--- a/tests/test_redshift_integration.py
+++ b/tests/test_redshift_integration.py
@@ -125,8 +125,8 @@ class TestRedshiftSystemViewDetection:
 
     def test_schema_name_normalized_to_lowercase(self):
         """Schema name should be lowercased on init."""
-        repo = RedshiftRepository("redshift://u:p@h:5439/db", schema_name="DWH_Antares")
-        assert repo.schema_name == "dwh_antares"
+        repo = RedshiftRepository("redshift://u:p@h:5439/db", schema_name="ANALYTICS")
+        assert repo.schema_name == "analytics"
 
     def test_process_bulk_rows_empty(self):
         """Empty rows should produce empty table list."""

--- a/tests/test_retrieval_pipeline.py
+++ b/tests/test_retrieval_pipeline.py
@@ -1,0 +1,489 @@
+"""Tests for the new retrieval pipeline and execution-aware repair flow."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from nlp2sql.adapters.default_error_classifier import DefaultErrorClassifier
+from nlp2sql.adapters.default_repair_policy import DefaultRepairPolicy
+from nlp2sql.core.entities import (
+    CanonicalQueryPattern,
+    DatabaseType,
+    DimensionDefinition,
+    DomainRule,
+    MetricDefinition,
+    SemanticContext,
+    SemanticEntityMapping,
+)
+from nlp2sql.ports.ai_provider import QueryContext, QueryResponse
+from nlp2sql.services.example_selection_service import ExampleSelectionService
+from nlp2sql.services.prompt_assembly_service import PromptAssemblyService
+from nlp2sql.services.query_analysis_service import QueryAnalysisService
+from nlp2sql.services.query_repair_service import QueryRepairService
+from nlp2sql.services.query_service import QueryGenerationService
+from nlp2sql.services.semantic_resolution_service import SemanticResolutionService
+from nlp2sql.services.semantic_validation_service import SemanticValidationService
+from nlp2sql.services.sql_intent_planning_service import SqlIntentPlanningService
+from nlp2sql.utils.semantic_prompt import format_semantic_context_lines
+
+
+def _build_generic_funnel_semantic_context() -> SemanticContext:
+    return SemanticContext(
+        domain="funnel",
+        canonical_tables=["conversion_funnel"],
+        supporting_tables=["channel_summary"],
+        required_filters=["store = 'demo_store'", "region = 'north_america'"],
+        preferred_time_logic=["Use the date column for time windows."],
+        disallowed_tables=["legacy_channel_rollup"],
+        prompt_hints=["Preserve funnel groupings when the question asks for a breakdown."],
+        entity_mappings=[
+            SemanticEntityMapping(
+                source_term="Demo Store North America",
+                target="store_region",
+                resolved_value="demo_store / north_america",
+                filter_expression="store = 'demo_store' AND region = 'north_america'",
+            )
+        ],
+        metric_definitions=[
+            MetricDefinition(
+                name="sessions",
+                description="Top-of-funnel visits.",
+                source_columns=["sessions"],
+                synonyms=["visitors", "traffic"],
+            ),
+            MetricDefinition(
+                name="atc_rate",
+                expression="SUM(atc_users)::float / NULLIF(SUM(sessions), 0)",
+                description="Add-to-cart rate.",
+                source_columns=["atc_users", "sessions"],
+                synonyms=["add_to_cart_rate"],
+            ),
+            MetricDefinition(
+                name="cvr",
+                expression="SUM(conversions)::float / NULLIF(SUM(sessions), 0)",
+                description="Conversion rate.",
+                source_columns=["conversions", "sessions"],
+                synonyms=["conversion_rate"],
+            ),
+        ],
+        dimension_definitions=[
+            DimensionDefinition(
+                name="source_category",
+                description="Traffic source grouping.",
+                synonyms=["channel_group", "traffic_source"],
+                allowed_values=["Email", "Paid Social", "Organic Search"],
+            ),
+            DimensionDefinition(
+                name="date",
+                description="Daily reporting grain.",
+                synonyms=["day"],
+            ),
+        ],
+        rules=[
+            DomainRule(
+                name="preserve_source_breakdown",
+                description="Keep source_category grouping when the user asks for a source breakdown.",
+                required_dimensions=["source_category"],
+                required_filters=["store = 'demo_store'"],
+                preferred_tables=["conversion_funnel"],
+            )
+        ],
+        patterns=[
+            CanonicalQueryPattern(
+                name="daily_funnel_by_source",
+                description="Daily funnel trend by source category.",
+                preferred_tables=["conversion_funnel"],
+                metric_names=["sessions", "atc_rate", "cvr"],
+                dimension_names=["date", "source_category"],
+            )
+        ],
+    )
+
+
+class TestQueryAnalysisService:
+    """Tests for the query analysis and retrieval plan step."""
+
+    def test_analysis_extracts_intent_and_keywords(self):
+        service = QueryAnalysisService()
+
+        plan = service.analyze("Show daily revenue by channel for the last 7 days")
+
+        assert plan.intent_context.intent.value in {"group", "aggregate"}
+        assert "revenue" in plan.intent_context.metrics
+        assert "channel" in plan.intent_context.dimensions
+        assert any(token in plan.intent_context.time_grains for token in ("daily", "days"))
+        assert "revenue" in plan.example_query
+
+
+class _FakeExampleRepository:
+    async def add_examples(self, examples):  # pragma: no cover - unused in test
+        del examples
+
+    async def search_similar(self, question, top_k=5, database_type=None, min_score=0.3):
+        del question, top_k, database_type, min_score
+        return [
+            {
+                "question": "Top products by revenue",
+                "sql": "SELECT product, SUM(revenue) FROM product_metrics GROUP BY product ORDER BY SUM(revenue) DESC",
+                "database_type": "postgres",
+                "similarity_score": 0.92,
+                "metadata": {"tables": ["product_metrics"], "intent": "aggregate"},
+            },
+            {
+                "question": "Revenue by channel for the last 7 days",
+                "sql": "SELECT channel, SUM(revenue) FROM channel_metrics WHERE date >= CURRENT_DATE - INTERVAL '7 days' GROUP BY channel",
+                "database_type": "postgres",
+                "similarity_score": 0.55,
+                "metadata": {"tables": ["channel_metrics"], "intent": "aggregate"},
+            },
+        ]
+
+    async def clear(self):  # pragma: no cover - unused in test
+        return None
+
+    def get_stats(self):  # pragma: no cover - unused in test
+        return {"total_examples": 2}
+
+
+class TestExampleSelectionService:
+    """Tests for schema-aware example reranking."""
+
+    @pytest.mark.asyncio
+    async def test_prefers_schema_aligned_example_over_higher_semantic_score(self):
+        query_analysis = QueryAnalysisService()
+        retrieval_plan = query_analysis.analyze("Revenue by channel for the last 7 days")
+        service = ExampleSelectionService(
+            example_store=_FakeExampleRepository(),
+            max_examples=2,
+            max_prompt_examples=2,
+        )
+
+        selected = await service.select_examples(
+            question="Revenue by channel for the last 7 days",
+            database_type=DatabaseType.POSTGRES,
+            retrieval_plan=retrieval_plan,
+            relevant_tables=[("channel_metrics", 0.95)],
+        )
+
+        assert selected[0]["metadata"]["tables"] == ["channel_metrics"]
+        assert selected[0]["metadata"]["rerank_score"] > selected[1]["metadata"]["rerank_score"]
+
+
+class TestPromptAssemblyService:
+    """Tests for final query context assembly."""
+
+    def test_prompt_assembly_keeps_analysis_metadata(self):
+        query_analysis = QueryAnalysisService()
+        retrieval_plan = query_analysis.analyze("Revenue by channel for the last 7 days")
+        service = PromptAssemblyService()
+        semantic_context = SemanticContext(
+            domain="sales",
+            canonical_tables=["channel_performance"],
+            required_filters=["segment = 'growth'"],
+            entity_mappings=[
+                SemanticEntityMapping(
+                    source_term="North America growth",
+                    target="sales_segment",
+                    resolved_value="north_america / growth",
+                    filter_expression="region = 'north_america' AND segment = 'growth'",
+                )
+            ],
+        )
+
+        query_context = service.build_query_context(
+            question="Revenue by channel for the last 7 days",
+            database_type="postgres",
+            schema_context="Table: channel_metrics",
+            retrieval_plan=retrieval_plan,
+            examples=[],
+            semantic_context=semantic_context,
+            sql_intent_plan=SqlIntentPlanningService().build(
+                retrieval_plan=retrieval_plan,
+                semantic_context=semantic_context,
+                relevant_tables=[("channel_performance", 0.9)],
+                examples=[],
+            ),
+            max_tokens=1000,
+            temperature=0.1,
+        )
+
+        assert query_context.metadata["intent_context"]["metrics"] == ["revenue"]
+        assert "example_query" in query_context.metadata["retrieval_plan"]
+        assert query_context.metadata["semantic_context"]["domain"] == "sales"
+        assert query_context.metadata["sql_intent_plan"]["fact_table"] == "channel_performance"
+
+    def test_prompt_assembly_keeps_rich_funnel_semantic_metadata(self):
+        query_analysis = QueryAnalysisService()
+        retrieval_plan = query_analysis.analyze("Show funnel sessions and CVR by source category")
+        semantic_context = _build_generic_funnel_semantic_context()
+
+        query_context = PromptAssemblyService().build_query_context(
+            question="Show funnel sessions and CVR by source category",
+            database_type="postgres",
+            schema_context="Table: conversion_funnel",
+            retrieval_plan=retrieval_plan,
+            examples=[],
+            semantic_context=semantic_context,
+            sql_intent_plan=SqlIntentPlanningService().build(
+                retrieval_plan=retrieval_plan,
+                semantic_context=semantic_context,
+                relevant_tables=[("conversion_funnel", 0.95), ("legacy_channel_rollup", 0.60)],
+                examples=[],
+            ),
+            max_tokens=1000,
+            temperature=0.1,
+        )
+
+        semantic_metadata = query_context.metadata["semantic_context"]
+        assert semantic_metadata["metric_definitions"][1]["name"] == "atc_rate"
+        assert "SUM(atc_users)" in semantic_metadata["metric_definitions"][1]["expression"]
+        assert semantic_metadata["dimension_definitions"][0]["name"] == "source_category"
+        assert semantic_metadata["rules"][0]["required_dimensions"] == ["source_category"]
+        assert semantic_metadata["patterns"][0]["dimension_names"] == ["date", "source_category"]
+        assert query_context.metadata["sql_intent_plan"]["metadata"]["candidate_tables"] == ["conversion_funnel"]
+
+
+class TestSemanticPromptFormatting:
+    def test_formats_rich_semantic_context_for_prompt(self):
+        lines = format_semantic_context_lines(_build_generic_funnel_semantic_context().to_metadata())
+
+        assert "Business Context:" in lines
+        assert any("Metric definitions:" in line for line in lines)
+        assert any("atc_rate" in line and "expr=" in line for line in lines)
+        assert any("Dimension definitions:" in line for line in lines)
+        assert any("source_category" in line and "Traffic source grouping." in line for line in lines)
+        assert any("Business rules:" in line for line in lines)
+        assert any("preserve_source_breakdown" in line for line in lines)
+        assert any("Canonical query patterns:" in line for line in lines)
+        assert any("daily_funnel_by_source" in line for line in lines)
+
+
+class TestSemanticResolutionService:
+    @pytest.mark.asyncio
+    async def test_semantic_resolution_enriches_retrieval_plan(self):
+        query_analysis = QueryAnalysisService()
+        retrieval_plan = query_analysis.analyze("Revenue by channel for the north america growth segment")
+        semantic_context = SemanticContext(
+            domain="sales",
+            canonical_tables=["channel_performance"],
+            required_filters=["segment = 'growth'"],
+            metric_definitions=[MetricDefinition(name="net_revenue")],
+            entity_mappings=[
+                SemanticEntityMapping(
+                    source_term="north america growth",
+                    target="sales_segment",
+                    resolved_value="north_america / growth",
+                    filter_expression="region = 'north_america' AND segment = 'growth'",
+                )
+            ],
+        )
+        service = SemanticResolutionService()
+
+        resolved_context, enriched_plan = await service.resolve(
+            question="Revenue by channel for the north america growth segment",
+            retrieval_plan=retrieval_plan,
+            database_type=DatabaseType.POSTGRES,
+            semantic_context=semantic_context,
+        )
+
+        assert resolved_context.domain == "sales"
+        assert "channel_performance" in enriched_plan.retrieval_query
+        assert "net_revenue" in enriched_plan.example_query
+
+
+class TestSemanticValidationService:
+    @pytest.mark.asyncio
+    async def test_semantic_validation_flags_missing_required_filters(self):
+        service = SemanticValidationService()
+        semantic_context = SemanticContext(
+            domain="sales",
+            canonical_tables=["channel_performance"],
+            required_filters=["segment = 'growth'"],
+        )
+        sql_intent_plan = SqlIntentPlanningService().build(
+            retrieval_plan=QueryAnalysisService().analyze("Revenue by channel"),
+            semantic_context=semantic_context,
+            relevant_tables=[("channel_performance", 0.95)],
+            examples=[],
+        )
+
+        result = await service.validate(
+            "SELECT channel, SUM(net_revenue) FROM channel_performance GROUP BY channel",
+            semantic_context,
+            sql_intent_plan,
+        )
+
+        assert result.is_valid is False
+        assert any(issue.category == "missing_required_filter" for issue in result.issues)
+
+    @pytest.mark.asyncio
+    async def test_semantic_validation_flags_missing_required_dimensions(self):
+        service = SemanticValidationService()
+        semantic_context = _build_generic_funnel_semantic_context()
+        sql_intent_plan = SqlIntentPlanningService().build(
+            retrieval_plan=QueryAnalysisService().analyze("Show sessions by source category"),
+            semantic_context=semantic_context,
+            relevant_tables=[("conversion_funnel", 0.95)],
+            examples=[],
+        )
+
+        result = await service.validate(
+            "SELECT SUM(sessions) FROM conversion_funnel WHERE store = 'demo_store' AND region = 'north_america'",
+            semantic_context,
+            sql_intent_plan,
+        )
+
+        assert result.is_valid is False
+        assert any(issue.category == "missing_required_dimension" for issue in result.issues)
+
+
+class TestRepairLoop:
+    """Tests for execution-aware repair without a real database."""
+
+    @pytest.mark.asyncio
+    async def test_generate_response_pipeline_repairs_execution_failure(self):
+        provider = MagicMock()
+        provider.generate_query = AsyncMock(
+            side_effect=[
+                QueryResponse(
+                    sql="SELECT bad_column FROM orders",
+                    explanation="first attempt",
+                    confidence=0.4,
+                    tokens_used=10,
+                    provider="openai",
+                    metadata={},
+                ),
+                QueryResponse(
+                    sql="SELECT total_amount FROM orders",
+                    explanation="repaired",
+                    confidence=0.8,
+                    tokens_used=12,
+                    provider="openai",
+                    metadata={},
+                ),
+            ]
+        )
+        provider.validate_query = AsyncMock(return_value={"is_valid": True, "errors": [], "warnings": []})
+
+        service = object.__new__(QueryGenerationService)
+        service.ai_provider = provider
+        service.query_optimizer = None
+        service.enable_query_optimization = True
+        service.query_validator = None
+        service.execution_port = MagicMock()
+        service.execution_port.execute_readonly = AsyncMock(
+            side_effect=[Exception("column bad_column does not exist"), {"row_count": 1, "execution_time_ms": 3.2}]
+        )
+        service.error_classifier = DefaultErrorClassifier()
+        service.repair_policy = DefaultRepairPolicy(max_attempts=2)
+        service.query_repair_service = QueryRepairService(provider)
+        service.semantic_validation_service = SemanticValidationService()
+
+        query_context = QueryContext(
+            question="Total revenue",
+            database_type="postgres",
+            schema_context="Table: orders (total_amount)",
+            examples=[],
+            max_tokens=1000,
+            temperature=0.1,
+            metadata={},
+        )
+
+        response, validation, execution_validation, repair_attempts = await service._generate_response_pipeline(
+            query_context=query_context,
+            database_type=DatabaseType.POSTGRES,
+            execution_mode="generate_validate_repair",
+            timeout_seconds=5,
+        )
+
+        assert response.sql == "SELECT total_amount FROM orders"
+        assert validation["is_valid"] is True
+        assert execution_validation["success"] is True
+        assert len(repair_attempts) == 1
+
+    @pytest.mark.asyncio
+    async def test_generate_response_pipeline_repairs_semantic_failure_before_execution(self):
+        provider = MagicMock()
+        provider.generate_query = AsyncMock(
+            side_effect=[
+                QueryResponse(
+                    sql="SELECT channel, SUM(net_revenue) FROM channel_performance GROUP BY channel",
+                    explanation="first attempt",
+                    confidence=0.5,
+                    tokens_used=9,
+                    provider="openai",
+                    metadata={},
+                ),
+                QueryResponse(
+                    sql="SELECT channel, SUM(net_revenue) FROM channel_performance WHERE segment = 'growth' GROUP BY channel",
+                    explanation="semantic retry",
+                    confidence=0.8,
+                    tokens_used=12,
+                    provider="openai",
+                    metadata={},
+                ),
+            ]
+        )
+        provider.validate_query = AsyncMock(return_value={"is_valid": True, "errors": [], "warnings": []})
+
+        service = object.__new__(QueryGenerationService)
+        service.ai_provider = provider
+        service.query_optimizer = None
+        service.enable_query_optimization = True
+        service.query_validator = None
+        service.execution_port = MagicMock()
+        service.execution_port.execute_readonly = AsyncMock(return_value={"row_count": 1, "execution_time_ms": 1.2})
+        service.error_classifier = DefaultErrorClassifier()
+        service.repair_policy = DefaultRepairPolicy(max_attempts=2)
+        service.query_repair_service = QueryRepairService(provider)
+        service.semantic_validation_service = SemanticValidationService()
+
+        semantic_context = SemanticContext(
+            domain="sales",
+            canonical_tables=["channel_performance"],
+            required_filters=["segment = 'growth'"],
+        )
+        sql_intent_plan = SqlIntentPlanningService().build(
+            retrieval_plan=QueryAnalysisService().analyze("Revenue by channel"),
+            semantic_context=semantic_context,
+            relevant_tables=[("channel_performance", 0.95)],
+            examples=[],
+        )
+        query_context = QueryContext(
+            question="Revenue by channel",
+            database_type="postgres",
+            schema_context="Table: channel_performance (channel, net_revenue, segment)",
+            examples=[],
+            max_tokens=1000,
+            temperature=0.1,
+            metadata={
+                "semantic_context": semantic_context.to_metadata(),
+                "sql_intent_plan": sql_intent_plan.to_metadata(),
+            },
+        )
+
+        response, validation, execution_validation, repair_attempts = await service._generate_response_pipeline(
+            query_context=query_context,
+            database_type=DatabaseType.POSTGRES,
+            execution_mode="generate_validate_repair",
+            timeout_seconds=5,
+            semantic_context=semantic_context,
+            sql_intent_plan=sql_intent_plan,
+        )
+
+        assert response.sql.endswith("GROUP BY channel")
+        assert validation["semantic_validation"]["is_valid"] is True
+        assert execution_validation["success"] is True
+        assert any(attempt["type"] == "semantic_retry" for attempt in repair_attempts)
+
+    def test_redshift_dialect_validation_flags_known_issues(self):
+        service = object.__new__(QueryGenerationService)
+
+        issues = service._validate_dialect_rules(
+            "SELECT DISTINCT ON (user_id) STRING_AGG(name, ',') FROM users WHERE created_at >= CURRENT_DATE - INTERVAL '7 days'",
+            DatabaseType.REDSHIFT,
+        )
+
+        assert any("DISTINCT ON" in issue for issue in issues)
+        assert any("LISTAGG" in issue for issue in issues)
+        assert any("DATEADD" in issue for issue in issues)

--- a/uv.lock
+++ b/uv.lock
@@ -2064,7 +2064,7 @@ wheels = [
 
 [[package]]
 name = "nlp2sql"
-version = "0.2.0rc12"
+version = "0.2.0rc13"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

This PR upgrades `nlp2sql` from a mostly schema-and-question driven pipeline to a business-aware generation pipeline:

`question -> semantic resolution -> schema/examples retrieval -> SQL intent plan -> prompt assembly -> SQL -> semantic/execution validation -> optional repair`

It introduces a first-class semantic layer, structured intent planning before generation, semantic validation after generation, CLI support for semantic/example artifacts, and stronger public/local validation around the repository's e-commerce example domain.

## What changed

### Semantic domain model

Added first-class semantic entities:
- `SemanticContext`
- `SemanticEntityMapping`
- `MetricDefinition`
- `DimensionDefinition`
- `DomainRule`
- `CanonicalQueryPattern`
- `SqlIntentPlan`
- `SemanticIssue`
- `SemanticValidationResult`

### Ports and adapters

Added new extension points:
- `SemanticResolverPort`
- `SemanticValidatorPort`

Added initial adapters:
- `NoOpSemanticResolver`
- `NoOpSemanticValidator`
- `DictSemanticResolver`
- `FileSemanticResolver`

### Service orchestration

Upgraded `QueryGenerationService` to orchestrate:
- query analysis
- semantic resolution
- schema retrieval
- example selection
- SQL intent planning
- prompt assembly
- generation
- semantic validation
- optional execution validation and repair

Added supporting services:
- `SemanticResolutionService`
- `SqlIntentPlanningService`
- `SemanticValidationService`
- `PromptAssemblyService`
- `ExampleSelectionService`
- `QueryAnalysisService`
- `QueryRepairService`

### Public API

Exposed semantic support through the DSL:
- `connect(..., semantic_hooks=..., semantic_context=...)`
- `nlp.ask(..., semantic_context=...)`

Kept execution hooks and semantic hooks separate so downstream services can control them independently.

### CLI

Added support for:
- `--semantic-context-file`
- `--semantic-context-json`
- `--examples-file`
- `--examples-json`
- `--show-semantic-context`
- `--show-sql-intent-plan`
- `--show-selected-examples`
- `--validate`
- `--repair`

Centralized artifact loading in `utils/artifact_loader.py`.

### Prompting and metadata

Improved provider prompt rendering with richer business context and structured SQL intent plan metadata.

Added richer result metadata including:
- `semantic_context`
- `sql_intent_plan`
- `selected_examples`
- `repair_attempts`
- `execution_validation`

### Local integration validation

Expanded the local PostgreSQL e-commerce schema to better validate semantic disambiguation.

Added regression-style integration coverage showing semantic context can move generation from a plausible transactional path to the intended aggregate fact table.

Sanitized automated tests and public docs to avoid private warehouse identifiers.

### Docs and versioning

Refreshed public docs so they match the current DSL-first, semantic-aware architecture.

Bumped version to `0.2.0rc13`.

## Why

Few-shot examples alone were not enough to capture business meaning such as:
- canonical fact tables
- required filters
- required dimensions
- disallowed tables
- preferred query patterns

This PR adds the missing semantic/business layer directly to the library while preserving the hexagonal architecture and keeping the public API ergonomic.

## Validation

Ran:
- `uv lock`
- `uv sync`
- `uv run python -c "from nlp2sql import __version__; print(__version__)"`
- `uv run pytest -m "integration and not llm"`
- `uv run pytest -m "integration and llm"`

Results:
- version verified as `0.2.0rc13`
- `integration and not llm`: `21 passed, 6 skipped`
- `integration and llm`: `3 passed`

Notes:
- the skipped tests are LocalStack Redshift integration tests when local Redshift is not running
- local PostgreSQL semantic/e-commerce integration flow passed

## Follow-up

After this PR, the next step is to consume `nlp2sql` through a downstream `uv` source dependency and verify compatibility with an existing integration.

Closes #41
Closes #34
